### PR TITLE
Serve website with FastAPI

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import os
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
 
 import cursos
 import cursosom
@@ -68,14 +69,16 @@ app.include_router(mensagemdecobranca.router)
 app.include_router(site_page.router)
 
 
-
 # ──────────────────────────────────────────────────────────
 # Health-check
 # ──────────────────────────────────────────────────────────
-@app.get("/", tags=["Status"])
+@app.get("/status", tags=["Status"])
 def health():
     """Verifica se o serviço está operacional."""
     return {"status": "online", "version": app.version}
+
+static_dir = os.path.dirname(os.path.abspath(__file__))
+app.mount("/", StaticFiles(directory=static_dir, html=True), name="static")
 
 # ──────────────────────────────────────────────────────────
 # Execução local / Render


### PR DESCRIPTION
## Summary
- serve the repository root as static files
- move health-check to `/status`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py` *(fails: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6851727267e483268e3d0c0940277caa