### PR TITLE
Add option to skip course cache update on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ python main.py
 ```
 
 A API ficará disponível em `http://localhost:8000` (ou na porta definida pela variável `PORT`).
+Defina `SKIP_CACHE_UPDATE_ON_STARTUP=1` para evitar a tentativa de atualizar o cache de cursos ao iniciar o servidor.
 
 ## Principais rotas
 

--- a/kiwify.py
+++ b/kiwify.py
@@ -26,6 +26,9 @@ WHATSAPP_LOG_NUM = os.getenv("WHATSAPP_LOG_NUM", "556186660241")
 UNIDADE_ID = os.getenv("UNIDADE_ID")
 DISCORD_WEBHOOK = os.getenv("DISCORD_WEBHOOK")
 
+# Se definido como "1", desativa a atualização de cursos na inicialização
+SKIP_CACHE_UPDATE_ON_STARTUP = os.getenv("SKIP_CACHE_UPDATE_ON_STARTUP", "0") in ("1", "true", "True")
+
 # Variáveis para credenciais do Google
 GOOGLE_CREDENTIALS_JSON = os.getenv("GOOGLE_CREDENTIALS_JSON")  # Para segredos em texto
 GOOGLE_SHEETS_CREDENTIALS_PATH = os.getenv(
@@ -508,4 +511,5 @@ async def secure_refresh_all():
 async def startup_event():
     """Executa na inicialização da aplicação."""
     obter_token_unidade()
-    atualizar_cache_cursos_om()
+    if not SKIP_CACHE_UPDATE_ON_STARTUP:
+        atualizar_cache_cursos_om()


### PR DESCRIPTION
## Summary
- allow skipping OM course cache update via `SKIP_CACHE_UPDATE_ON_STARTUP` env var
- document new env var in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6851937406988326acf858e68c170071