### PR TITLE
Implement free trial enrollment

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,3 +123,14 @@ POST /assinantes
 }
 ```
 
+
+## Passo a passo para o teste gratuito
+
+1. Acesse <https://www.cedbrasilia.com.br> e clique na aba **Cursos**.
+2. Escolha a opção **Iniciar teste gratuito** no curso desejado.
+3. Preencha nome completo, CPF e WhatsApp no formulário e confirme.
+4. Você será automaticamente matriculado para um período de 3 dias sem custos.
+5. Um WhatsApp de boas-vindas será enviado informando a data de término do teste.
+6. No dia do fim do teste, às 7h, você receberá uma mensagem de cobrança para manter o acesso.
+7. Caso o pagamento não seja reconhecido, sua conta será bloqueada automaticamente.
+

--- a/main.py
+++ b/main.py
@@ -17,6 +17,7 @@ import bloquear
 import login
 import auth
 import site_page
+import trial
 from app import whatsapp
 
 
@@ -27,16 +28,14 @@ app = FastAPI(
     title="API CED – Matrícula Automática",
     version="1.0.0",
     docs_url="/docs",
-    redoc_url="/redoc"
+    redoc_url="/redoc",
 )
 
 # ──────────────────────────────────────────────────────────
 # CORS – Domínios permitidos (ajustar via ORIGINS no .env)
 # ──────────────────────────────────────────────────────────
 origins = [
-    origin.strip()
-    for origin in os.getenv("ORIGINS", "*").split(",")
-    if origin.strip()
+    origin.strip() for origin in os.getenv("ORIGINS", "*").split(",") if origin.strip()
 ]
 
 app.add_middleware(
@@ -50,20 +49,21 @@ app.add_middleware(
 # ──────────────────────────────────────────────────────────
 # Registro dos roteadores
 # ──────────────────────────────────────────────────────────
-app.include_router(cursos.router,     prefix="/cursos",     tags=["Cursos"])
-app.include_router(cursosom.router,   prefix="/cursosom",   tags=["Cursos OM"])
-app.include_router(secure.router,                        tags=["Autenticação"])
+app.include_router(cursos.router, prefix="/cursos", tags=["Cursos"])
+app.include_router(cursosom.router, prefix="/cursosom", tags=["Cursos OM"])
+app.include_router(secure.router, tags=["Autenticação"])
 app.include_router(matricular.router, prefix="/matricular", tags=["Matrícula"])
-app.include_router(alunos.router,     prefix="/alunos",     tags=["Alunos"])
-app.include_router(kiwify.router,     prefix="/kiwify", tags=["Kiwify"])
-app.include_router(asaas.router,  tags=["Matrícula Assas"])
+app.include_router(alunos.router, prefix="/alunos", tags=["Alunos"])
+app.include_router(kiwify.router, prefix="/kiwify", tags=["Kiwify"])
+app.include_router(asaas.router, tags=["Matrícula Assas"])
 app.include_router(assinantes.router)
 app.include_router(msgasaas.router)
-app.include_router(deletar.router,    tags=["Excluir Aluno"])
-app.include_router(bloquear.router,   tags=["Bloqueio"])
-app.include_router(login.router,      prefix="/login",     tags=["Login"])
+app.include_router(deletar.router, tags=["Excluir Aluno"])
+app.include_router(bloquear.router, tags=["Bloqueio"])
+app.include_router(login.router, prefix="/login", tags=["Login"])
 app.include_router(auth.router)
 app.include_router(whatsapp.router)
+app.include_router(trial.router)
 app.include_router(site_page.router)
 
 
@@ -75,6 +75,7 @@ def health():
     """Verifica se o serviço está operacional."""
     return {"status": "online", "version": app.version}
 
+
 static_dir = os.path.dirname(os.path.abspath(__file__))
 app.mount("/", StaticFiles(directory=static_dir, html=True), name="static")
 
@@ -83,5 +84,6 @@ app.mount("/", StaticFiles(directory=static_dir, html=True), name="static")
 # ──────────────────────────────────────────────────────────
 if __name__ == "__main__":
     import uvicorn
+
     port = int(os.getenv("PORT", 8000))  # Render define PORT dinamicamente
     uvicorn.run("main:app", host="0.0.0.0", port=port, reload=False)

--- a/trial.py
+++ b/trial.py
@@ -1,0 +1,158 @@
+import os
+import json
+from datetime import datetime, timedelta, time
+from typing import List, Dict
+import requests
+from fastapi import APIRouter, HTTPException
+
+from matricular import _cadastrar_aluno_om, _obter_token_unidade
+from bloquear import _alterar_bloqueio
+from asaas import obter_cliente_por_cpf
+
+router = APIRouter(prefix="/teste-gratis", tags=["Teste Gratuito"])
+
+TRIAL_DAYS = 3
+TRIALS_FILE = os.getenv("TRIALS_FILE", "trials.json")
+SENHA_PADRAO = os.getenv("SENHA_PADRAO", "1234567")
+
+
+def _load_trials() -> List[Dict]:
+    if os.path.exists(TRIALS_FILE):
+        try:
+            with open(TRIALS_FILE, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except Exception:
+            return []
+    return []
+
+
+def _save_trials(trials: List[Dict]) -> None:
+    with open(TRIALS_FILE, "w", encoding="utf-8") as f:
+        json.dump(trials, f, ensure_ascii=False, indent=2)
+
+
+def _trial_end_date() -> datetime:
+    return datetime.now() + timedelta(days=TRIAL_DAYS)
+
+
+def _send_mensagem_teste(
+    nome: str, whatsapp: str, curso: str, cpf: str, fim: str
+) -> None:
+    msg = (
+        f"👋 Olá, {nome}!\n\n"
+        f"🎉 Seja bem-vindo(a) ao CED BRASIL!\n\n"
+        f"📚 Curso adquirido: {curso}\n\n"
+        f"🔐 Seu login: {cpf}\n"
+        f"🔑 Sua senha: {SENHA_PADRAO}\n\n"
+        f"Fim do teste gratuito em: {fim}\n\n"
+        "🌐 Portal do Aluno: https://www.cedbrasilia.com.br/login\n"
+        "🤖 APP Android: https://play.google.com/store/apps/datasafety?id=br.com.om.app&hl=pt_BR\n"
+        "🍎 APP iOS: https://apps.apple.com/br/app/meu-app-de-cursos/id1581898914"
+    )
+    try:
+        requests.get(
+            "https://whatsapptest-stij.onrender.com/send",
+            params={"para": whatsapp, "mensagem": msg},
+            timeout=10,
+        )
+    except Exception:
+        pass
+
+
+@router.post("")
+def iniciar_teste(dados: dict):
+    nome = dados.get("nome")
+    whatsapp = dados.get("whatsapp")
+    curso = dados.get("curso") or (dados.get("cursos") or [None])[0]
+    cpf = dados.get("cpf")
+    if not nome or not whatsapp or not curso:
+        raise HTTPException(400, "Campos obrigatórios ausentes")
+    try:
+        token = _obter_token_unidade()
+        aluno_id, cpf_res = _cadastrar_aluno_om(
+            nome,
+            whatsapp,
+            None,
+            [_id for _id in []],
+            token,
+            SENHA_PADRAO,
+            cpf=cpf,
+        )
+        fim = _trial_end_date()
+        data_fim = fim.strftime("%d/%m/%Y")
+        _send_mensagem_teste(nome, whatsapp, curso, cpf_res, data_fim)
+        trials = _load_trials()
+        trials.append(
+            {
+                "aluno_id": aluno_id,
+                "cpf": cpf_res,
+                "whatsapp": whatsapp,
+                "nome": nome,
+                "curso": curso,
+                "fim": fim.isoformat(),
+                "notificado": False,
+            }
+        )
+        _save_trials(trials)
+        return {"status": "ok", "aluno_id": aluno_id, "cpf": cpf_res, "fim": data_fim}
+    except Exception as e:
+        raise HTTPException(500, str(e))
+
+
+@router.post("/verificar")
+def verificar_testes():
+    agora = datetime.now()
+    trials = _load_trials()
+    atualizados = []
+    for t in trials:
+        if t.get("notificado"):
+            atualizados.append(t)
+            continue
+        fim = datetime.fromisoformat(t["fim"])
+        if agora >= datetime.combine(fim.date(), time(hour=7)):
+            _enviar_cobranca(t)
+            t["notificado"] = True
+            if not _assinatura_ativa(t["cpf"]):
+                try:
+                    _alterar_bloqueio(t["aluno_id"], 1)
+                except Exception:
+                    pass
+        atualizados.append(t)
+    _save_trials(atualizados)
+    return {"verificados": len(atualizados)}
+
+
+def _enviar_cobranca(t: Dict) -> None:
+    msg = f"Olá {t['nome']}, seu teste gratuito encerrou. Para continuar estudando, entre em contato e regularize o pagamento."
+    try:
+        requests.get(
+            "https://whatsapptest-stij.onrender.com/send",
+            params={"para": t["whatsapp"], "mensagem": msg},
+            timeout=10,
+        )
+    except Exception:
+        pass
+
+
+def _assinatura_ativa(cpf: str) -> bool:
+    cid = obter_cliente_por_cpf(cpf)
+    if not cid:
+        return False
+    try:
+        r = requests.get(
+            f"{os.getenv('ASAAS_BASE_URL', 'https://api.asaas.com/v3')}/subscriptions",
+            params={"customer": cid},
+            headers={
+                "Content-Type": "application/json",
+                "access_token": os.getenv("ASAAS_KEY"),
+            },
+            timeout=10,
+        )
+        if r.ok:
+            dados = r.json().get("data") or []
+            for sub in dados:
+                if sub.get("status") == "ACTIVE":
+                    return True
+    except Exception:
+        pass
+    return False


### PR DESCRIPTION
## Summary
- add router for `/teste-gratis` to register students on a 3‑day trial and store trial information
- send WhatsApp welcome message with trial end date
- on `/teste-gratis/verificar` check expired trials, send billing reminder and block account if no active subscription
- wire new router in `main.py`
- document step‑by‑step instructions for using the free trial

## Testing
- `python -m py_compile trial.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_6852943509108326a71c2ecb5e1ccb5b