### PR TITLE
Adiciona fluxo de teste gratuito

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ POST /assinantes
 2. Escolha a opção **Iniciar teste gratuito** no curso desejado.
 3. Preencha nome completo, CPF e WhatsApp no formulário e confirme.
 4. Você será automaticamente matriculado para um período de 3 dias sem custos.
-5. Um WhatsApp de boas-vindas será enviado informando a data de término do teste.
-6. No dia do fim do teste, às 7h, você receberá uma mensagem de cobrança para manter o acesso.
-7. Caso o pagamento não seja reconhecido, sua conta será bloqueada automaticamente.
+5. Você receberá um WhatsApp de boas-vindas com seu login e a data de vencimento.
+6. A cobrança é criada no ASAAS com vencimento em 3 dias e o link é enviado normalmente.
+7. Caso o pagamento não seja reconhecido, sua conta poderá ser bloqueada automaticamente.
 

--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ import bloquear
 import login
 import auth
 import site_page
-import trial
+import testegratuito
 from app import whatsapp
 
 
@@ -63,7 +63,7 @@ app.include_router(bloquear.router, tags=["Bloqueio"])
 app.include_router(login.router, prefix="/login", tags=["Login"])
 app.include_router(auth.router)
 app.include_router(whatsapp.router)
-app.include_router(trial.router)
+app.include_router(testegratuito.router)
 app.include_router(site_page.router)
 
 

--- a/testegratuito.py
+++ b/testegratuito.py
@@ -1,0 +1,96 @@
+import os
+from datetime import datetime, timedelta
+from typing import List
+
+import requests
+from fastapi import APIRouter, HTTPException
+
+from cursos import CURSOS_OM
+from matricular import (
+    _obter_token_unidade,
+    _cadastrar_aluno_om,
+    _send_whatsapp_chatpro,
+)
+from asaas import _criar_ou_obter_cliente, ASAAS_BASE_URL, _headers
+from utils import parse_valor
+
+router = APIRouter(prefix="/teste-gratis", tags=["Teste Gratuito"])
+
+TRIAL_DIAS = 3
+SENHA_PADRAO = os.getenv("SENHA_PADRAO", "1234567")
+VALOR_PADRAO = parse_valor(os.getenv("ASSINATURA_VALOR_PADRAO", "0")) or 0.0
+BILLING_TYPE = os.getenv("ASAAS_BILLING_TYPE", "UNDEFINED")
+
+
+def _calc_vencimento() -> str:
+    return (datetime.now() + timedelta(days=TRIAL_DIAS)).strftime("%Y-%m-%d")
+
+
+@router.post("")
+def iniciar_teste(dados: dict):
+    nome = dados.get("nome")
+    whatsapp = dados.get("whatsapp")
+    cpf = dados.get("cpf")
+    curso = dados.get("curso") or (dados.get("cursos") or [None])[0]
+
+    if not nome or not whatsapp or not curso:
+        raise HTTPException(400, "Campos obrigatórios ausentes")
+
+    cursos_ids: List[int] | None = CURSOS_OM.get(curso)
+    if not cursos_ids:
+        raise HTTPException(404, "Curso não encontrado")
+
+    try:
+        token = _obter_token_unidade()
+        aluno_id, cpf_res = _cadastrar_aluno_om(
+            nome,
+            whatsapp,
+            None,
+            cursos_ids,
+            token,
+            SENHA_PADRAO,
+            cpf=cpf,
+        )
+
+        customer_id = _criar_ou_obter_cliente(nome, cpf_res, whatsapp)
+        venc_iso = _calc_vencimento()
+        payload = {
+            "customer": customer_id,
+            "billingType": BILLING_TYPE,
+            "value": VALOR_PADRAO,
+            "cycle": "MONTHLY",
+            "nextDueDate": venc_iso,
+            "description": curso,
+            "externalReference": ",".join(map(str, cursos_ids)),
+        }
+        resp = requests.post(
+            f"{ASAAS_BASE_URL}/subscriptions",
+            json=payload,
+            headers=_headers(),
+            timeout=10,
+        )
+        if not resp.ok:
+            raise HTTPException(resp.status_code, resp.text)
+
+        vence_fmt = datetime.fromisoformat(venc_iso).strftime("%d/%m/%Y")
+        _send_whatsapp_chatpro(nome, whatsapp, [curso], cpf_res, vencimento=vence_fmt)
+
+        data = resp.json()
+        url = (
+            data.get("chargeUrl")
+            or data.get("invoiceUrl")
+            or data.get("bankSlipUrl")
+            or data.get("transactionReceiptUrl")
+        )
+
+        return {
+            "status": "ok",
+            "aluno_id": aluno_id,
+            "cpf": cpf_res,
+            "subscription": data.get("id"),
+            "fatura_url": url,
+        }
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(500, str(e))


### PR DESCRIPTION
## Summary
- implementar novo módulo `testegratuito.py` para matrícula de teste grátis
- incluir nova rota no `main.py`
- atualizar passo a passo no README

## Testing
- `python -m py_compile testegratuito.py main.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6852a50c50208326b6f31ee0bebb3b70