### PR TITLE
Ajusta SMS no teste gratuito

### DIFF
--- a/asaas.py
+++ b/asaas.py
@@ -163,8 +163,7 @@ def _enviar_whatsapp_checkout(nome: str, phone: str, url: str) -> None:
     mensagem = (
         f"👋 Olá {nome}, tudo bem?\n\n"
         f"Segue o link para pagamento do seu curso: {url}\n"
-        "Também enviamos este link via SMS.\n"
-        "Assim que o pagamento for confirmado, enviaremos seus dados de acesso.\n\n"
+        "Assim que o pagamento for confirmado, enviaremos seus dados de acesso via WhatsApp.\n\n"
         "Qualquer dúvida, estou à disposição para ajudar!"
     )
     try:

--- a/assinatura.html
+++ b/assinatura.html
@@ -332,7 +332,7 @@
 
                     if (response.ok) {
                         // Dispara mensagem de WhatsApp informando o início da matrícula
-                        const msg = `Olá ${data.nome} tudo bem?\nAcabamos de te enviar um SMS com o link da sua assinatura!\nVamos te matricular assim que confirmarmos o pagamento!\nQualquer duvida, estou aqui!`;
+                        const msg = `Olá ${data.nome} tudo bem?\nAcabamos de te enviar o link da sua assinatura no WhatsApp!\nVamos te matricular assim que confirmarmos o pagamento!\nQualquer duvida, estou aqui!`;
                         fetch(`https://whatsapptest-stij.onrender.com/send?para=${data.whatsapp}&mensagem=${encodeURIComponent(msg)}`)
                           .catch(() => {});
                         enrollmentCard.style.display = 'none';

--- a/index.html
+++ b/index.html
@@ -1146,7 +1146,7 @@
                         cursos_ids: selectedCourse.ids
                     };
                     await criarAssinatura(dados);
-                    const successText = `Sua matrícula foi gerada, ${nome}! Enviamos os dados da assinatura no seu SMS - (ASAAS)!`;
+                    const successText = `Sua matrícula foi gerada, ${nome}! Enviamos os dados da assinatura no seu WhatsApp!`;
                     checkoutMsg.textContent = successText;
                     checkoutMsg.className = 'text-center text-green-500 mt-2 h-5';
                     const successMsgEl = document.getElementById('success-message');

--- a/matricularassas.js
+++ b/matricularassas.js
@@ -124,7 +124,7 @@ document.addEventListener('DOMContentLoaded', () => {
         body: JSON.stringify({ nome, cpf, phone, cursos })
       });
       if (!res.ok) throw new Error('Falha ao conectar');
-      const msg = `Olá ${nome} tudo bem?\nAcabamos de te enviar um SMS com o link da sua assinatura!\nVamos te matricular assim que confirmarmos o pagamento!\nQualquer duvida, estou aqui!`;
+      const msg = `Olá ${nome} tudo bem?\nAcabamos de te enviar o link da sua assinatura no WhatsApp!\nVamos te matricular assim que confirmarmos o pagamento!\nQualquer duvida, estou aqui!`;
       fetch(`https://whatsapptest-stij.onrender.com/send?para=${phone}&mensagem=${encodeURIComponent(msg)}`)
         .catch(() => {});
       formMessage.textContent = `Sua matrícula foi gerada, ${nome}! Enviamos os dados da assinatura no seu whatsapp!`;

--- a/testegratuito.py
+++ b/testegratuito.py
@@ -64,6 +64,7 @@ def iniciar_teste(dados: dict):
             "nextDueDate": venc_iso,
             "description": curso,
             "externalReference": ",".join(map(str, cursos_ids)),
+            "notifyCustomer": False,
         }
         resp = requests.post(
             f"{ASAAS_BASE_URL}/subscriptions",


### PR DESCRIPTION
## Summary
- remove references to SMS in WhatsApp messages
- evita que o ASAAS envie notificações via SMS ao iniciar teste gratuito

## Testing
- `python -m py_compile asaas.py testegratuito.py`

------
https://chatgpt.com/codex/tasks/task_e_68531aea976c8326a25d0695a1c0ab91