### PR TITLE
Configurar logs via WhatsApp

### DIFF
--- a/log_config.py
+++ b/log_config.py
@@ -1,0 +1,44 @@
+import logging
+import os
+import requests
+
+from utils import formatar_numero_whatsapp
+
+WHATSAPP_URL = "https://whatsapptest-stij.onrender.com/send"
+WHATSAPP_LOG_NUM = os.getenv("WHATSAPP_LOG_NUM", "556186660241")
+
+class WhatsAppHandler(logging.Handler):
+    """Envia logs para o WhatsApp configurado."""
+
+    def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover
+        numero = formatar_numero_whatsapp(WHATSAPP_LOG_NUM)
+        if not numero:
+            return
+        mensagem = self.format(record)
+        try:
+            requests.get(
+                WHATSAPP_URL,
+                params={"para": numero, "mensagem": mensagem},
+                timeout=10,
+            )
+        except Exception:
+            # Evita quebra do logger em caso de falha
+            pass
+
+def setup_logging() -> None:
+    """Configura o logging padrão e o handler do WhatsApp."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+    )
+    if os.getenv("DISABLE_WA_LOG", "0") not in ("1", "true", "True"):
+        handler = WhatsAppHandler()
+        handler.setLevel(logging.INFO)
+        handler.setFormatter(
+            logging.Formatter("%(asctime)s [%(levelname)s] %(message)s")
+        )
+        logging.getLogger().addHandler(handler)
+
+def send_startup_message() -> None:
+    """Envia uma mensagem informando que o servidor iniciou."""
+    logging.info("🚀 Servidor iniciado com sucesso.")

--- a/main.py
+++ b/main.py
@@ -3,6 +3,10 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
+from log_config import setup_logging, send_startup_message
+
+setup_logging()
+
 import cursos
 import cursosom
 import secure
@@ -64,6 +68,11 @@ app.include_router(login.router, prefix="/login", tags=["Login"])
 app.include_router(auth.router)
 app.include_router(whatsapp.router)
 app.include_router(testegratuito.router)
+
+@app.on_event("startup")
+async def _on_startup() -> None:
+    """Dispara aviso de inicialização via WhatsApp."""
+    send_startup_message()
 
 
 # ──────────────────────────────────────────────────────────

--- a/matricular.py
+++ b/matricular.py
@@ -1,6 +1,7 @@
 import os
 import threading
 from typing import List, Tuple, Optional
+import logging
 import requests
 from fastapi import APIRouter, HTTPException
 from utils import formatar_numero_whatsapp
@@ -27,9 +28,9 @@ DISCORD_WEBHOOK_URL = "https://discord.com/api/webhooks/1377838283975036928/IgVv
 CPF_PREFIXO = "20254158"
 cpf_lock = threading.Lock()
 
-def _log(msg: str):
-    agora = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    print(f"[{agora}] {msg}")
+def _log(msg: str) -> None:
+    """Registra mensagem no log padrão."""
+    logging.info(msg)
 
 def _obter_token_unidade() -> str:
     """


### PR DESCRIPTION
## Summary
- adicionar utilitário `log_config.py` com handler que envia logs para o WhatsApp
- configurar logging e mensagem de inicialização em `main.py`
- usar `logging` em `matricular.py` para enviar logs

## Testing
- `pytest -q`
- `python -m py_compile main.py matricular.py log_config.py`

------
https://chatgpt.com/codex/tasks/task_e_68534d14c974832684a109076f46a373