### PR TITLE
Adicionar seleção em massa em cobranças

### DIFF
--- a/sistema/index.html
+++ b/sistema/index.html
@@ -227,6 +227,7 @@
                         <table class="min-w-full">
                             <thead>
                                 <tr class="border-b border-gray-700">
+                                    <th class="px-6 py-3 text-left"><input type="checkbox" id="cobrancas-select-all" class="form-control bg-gray-700 border-gray-600 rounded" /></th>
                                     <th class="px-6 py-3 text-left text-xs font-semibold text-gray-400 uppercase tracking-wider">Nome</th>
                                     <th class="px-6 py-3 text-left text-xs font-semibold text-gray-400 uppercase tracking-wider">Valor</th>
                                     <th class="px-6 py-3 text-left text-xs font-semibold text-gray-400 uppercase tracking-wider">Curso</th>
@@ -317,6 +318,10 @@
             <span id="assinantes-contador" class="text-sm text-gray-400 mr-4">0 selecionados</span>
             <button id="assinantes-excluir" class="bg-red-600 hover:bg-red-700 text-white font-bold px-4 py-2 rounded-lg flex items-center gap-2"><i class="fas fa-trash"></i> Excluir</button>
         </div>
+        <div id="cobrancas-drawer" class="hidden fixed bottom-0 left-0 right-0 bg-[#181818] p-4 border-t border-gray-800 flex justify-end items-center gap-3 shadow-lg">
+            <span id="cobrancas-contador" class="text-sm text-gray-400 mr-4">0 selecionados</span>
+            <button id="cobrancas-excluir" class="bg-red-600 hover:bg-red-700 text-white font-bold px-4 py-2 rounded-lg flex items-center gap-2"><i class="fas fa-trash"></i> Excluir</button>
+        </div>
     </div>
     
     <script>
@@ -370,6 +375,10 @@
             const assinantesDrawer = document.getElementById('assinantes-drawer');
             const assinantesContador = document.getElementById('assinantes-contador');
             const assinantesExcluirBtn = document.getElementById('assinantes-excluir');
+            const cobrancasSelectAll = document.getElementById('cobrancas-select-all');
+            const cobrancasDrawer = document.getElementById('cobrancas-drawer');
+            const cobrancasContador = document.getElementById('cobrancas-contador');
+            const cobrancasExcluirBtn = document.getElementById('cobrancas-excluir');
             const assinanteForm = document.getElementById('assinante-form');
             const assinanteFormFeedback = document.getElementById('assinante-form-feedback');
 
@@ -522,6 +531,13 @@
             assinantesSelectAll.addEventListener('change', () => {
                 document.querySelectorAll('.select-assinante').forEach(cb => cb.checked = assinantesSelectAll.checked);
                 updateAssinantesDrawer();
+            });
+
+            cobrancasExcluirBtn.addEventListener('click', deleteCobrancasSelecionadas);
+
+            cobrancasSelectAll.addEventListener('change', () => {
+                document.querySelectorAll('.select-cobranca').forEach(cb => cb.checked = cobrancasSelectAll.checked);
+                updateCobrancasDrawer();
             });
             
             selectAllCheckbox.addEventListener('change', () => {
@@ -913,6 +929,20 @@
                 return Array.from(document.querySelectorAll('.select-assinante:checked')).map(cb => cb.dataset.id);
             }
 
+            function updateCobrancasDrawer() {
+                const count = document.querySelectorAll('.select-cobranca:checked').length;
+                if (count > 0) {
+                    cobrancasDrawer.classList.remove('hidden');
+                    cobrancasContador.textContent = `${count} selecionado(s)`;
+                } else {
+                    cobrancasDrawer.classList.add('hidden');
+                }
+            }
+
+            function getCobrancasSelecionadas() {
+                return Array.from(document.querySelectorAll('.select-cobranca:checked')).map(cb => cb.dataset.id);
+            }
+
             async function deleteAssinantesSelecionados() {
                 const selecionados = getAssinantesSelecionados();
                 if (selecionados.length === 0) return;
@@ -923,6 +953,19 @@
                     fetchAssinantes();
                 } catch (err) {
                     alert(err.message || 'Erro ao deletar assinantes.');
+                }
+            }
+
+            async function deleteCobrancasSelecionadas() {
+                const selecionadas = getCobrancasSelecionadas();
+                if (selecionadas.length === 0) return;
+                if (!confirm(`Deseja realmente deletar as ${selecionadas.length} cobranças selecionadas?`)) return;
+                try {
+                    await Promise.all(selecionadas.map(id => fetch(`${API_BASE}/cobrancas/${id}`, { method: 'DELETE' })));
+                    alert('Cobranças removidas com sucesso!');
+                    fetchCobrancas();
+                } catch (err) {
+                    alert('Erro ao deletar cobranças.');
                 }
             }
 
@@ -1026,18 +1069,19 @@
             }
 
             async function fetchCobrancas() {
-                cobrancasTabela.innerHTML = `<tr><td class="px-6 py-4 text-center" colspan="6"><i class="fas fa-spinner fa-spin text-2xl spotify-green"></i></td></tr>`;
+                cobrancasTabela.innerHTML = `<tr><td class="px-6 py-4 text-center" colspan="7"><i class="fas fa-spinner fa-spin text-2xl spotify-green"></i></td></tr>`;
                 try {
                     const data = await listarCobrancas();
                     const cobrancas = Array.isArray(data) ? data : data.cobrancas || [];
                     if (cobrancas.length === 0) {
-                        cobrancasTabela.innerHTML = `<tr><td class="px-6 py-4 text-center" colspan="6">Nenhuma cobrança.</td></tr>`;
+                        cobrancasTabela.innerHTML = `<tr><td class="px-6 py-4 text-center" colspan="7">Nenhuma cobrança.</td></tr>`;
                     } else {
                         cobrancasTabela.innerHTML = cobrancas.map(c => {
                             const pago = c.status === 'RECEIVED' || c.status === 'CONFIRMED';
                             const statusClass = pago ? 'text-green-400' : 'text-red-500';
                             return `
                             <tr class="hover:bg-gray-700 transition-colors">
+                                <td class="px-6 py-4"><input type="checkbox" class="select-cobranca form-control" data-id="${c.id}"></td>
                                 <td class="px-6 py-4 font-medium">${c.nome || ''}</td>
                                 <td class="px-6 py-4 text-gray-400">${c.valor || ''}</td>
                                 <td class="px-6 py-4 text-gray-400">${c.descricao || ''}</td>
@@ -1053,9 +1097,12 @@
                         document.querySelectorAll('.delete-cobranca').forEach(b => b.addEventListener('click', () => deleteCobranca(b.dataset.id)));
                         document.querySelectorAll('.edit-cobranca').forEach(b => b.addEventListener('click', () => editCobranca(b.dataset.id)));
                         document.querySelectorAll('.msg-cobranca').forEach(b => b.addEventListener('click', () => enviarMsgCobranca(b.dataset)));
+                        document.querySelectorAll('.select-cobranca').forEach(cb => cb.addEventListener('change', updateCobrancasDrawer));
+                        cobrancasSelectAll.checked = false;
+                        updateCobrancasDrawer();
                     }
                 } catch (err) {
-                    cobrancasTabela.innerHTML = `<tr><td class="px-6 py-4 text-center text-red-500" colspan="6">Erro ao buscar cobranças.</td></tr>`;
+                    cobrancasTabela.innerHTML = `<tr><td class="px-6 py-4 text-center text-red-500" colspan="7">Erro ao buscar cobranças.</td></tr>`;
                 }
             }
 


### PR DESCRIPTION
## Summary
- incluir checkbox para selecionar todas as cobranças
- exibir drawer de ações em massa para cobranças
- permitir excluir múltiplas cobranças de uma vez

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68536869aec48326bd780e8c79fc3b2e