### PR TITLE
Impede ações duplicadas para CPF já cadastrado

### DIFF
--- a/asaas.py
+++ b/asaas.py
@@ -8,7 +8,7 @@ import requests
 from fastapi import APIRouter, HTTPException, Request
 
 from utils import formatar_numero_whatsapp, parse_valor
-from matricular import realizar_matricula
+from matricular import realizar_matricula, _buscar_aluno_id_por_cpf
 from cursos import CURSOS_OM
 import msgasaas
 
@@ -207,6 +207,9 @@ def _criar_checkout(
     if valor <= 0:
         raise HTTPException(400, "Valor inválido")
 
+    if cpf and _buscar_aluno_id_por_cpf(cpf):
+        raise HTTPException(409, "CPF já matriculado")
+
     customer_id = _criar_ou_obter_cliente(nome, cpf, phone, email, nascimento)
 
     payload = {
@@ -328,6 +331,9 @@ def criar_assinatura_recorrente(dados: dict, enviar_whatsapp: bool = True):
         raise HTTPException(400, "Campos obrigatórios ausentes")
     if valor <= 0:
         raise HTTPException(400, "Valor inválido")
+
+    if cpf and _buscar_aluno_id_por_cpf(cpf):
+        raise HTTPException(409, "CPF já matriculado")
 
     customer_id = _criar_ou_obter_cliente(nome, cpf, phone, dados.get("email"), dados.get("nascimento"))
     logger.info("Cliente ASAAS %s criado/obtido para %s", customer_id, phone)

--- a/assinantes.py
+++ b/assinantes.py
@@ -124,6 +124,9 @@ def adicionar_assinante(dados: dict):
     if valor <= 0:
         raise HTTPException(400, "Valor inválido")
 
+    if cpf and _buscar_aluno_id_por_cpf(cpf):
+        raise HTTPException(409, "CPF já matriculado")
+
     cid = _criar_ou_obter_cliente(
         nome,
         cpf,

--- a/testegratuito.py
+++ b/testegratuito.py
@@ -10,6 +10,7 @@ from matricular import (
     _obter_token_unidade,
     _cadastrar_aluno_om,
     _send_whatsapp_chatpro,
+    _buscar_aluno_id_por_cpf,
 )
 from asaas import _criar_ou_obter_cliente, ASAAS_BASE_URL, _headers
 from utils import parse_valor
@@ -40,6 +41,9 @@ def iniciar_teste(dados: dict):
     cursos_ids: List[int] | None = CURSOS_OM.get(curso)
     if not cursos_ids:
         raise HTTPException(404, "Curso não encontrado")
+
+    if cpf and _buscar_aluno_id_por_cpf(cpf):
+        raise HTTPException(409, "CPF já matriculado")
 
     try:
         token = _obter_token_unidade()

--- a/trial.py
+++ b/trial.py
@@ -5,7 +5,7 @@ from typing import List, Dict
 import requests
 from fastapi import APIRouter, HTTPException
 
-from matricular import _cadastrar_aluno_om, _obter_token_unidade
+from matricular import _cadastrar_aluno_om, _obter_token_unidade, _buscar_aluno_id_por_cpf
 from bloquear import _alterar_bloqueio
 from asaas import obter_cliente_por_cpf
 
@@ -67,6 +67,8 @@ def iniciar_teste(dados: dict):
     cpf = dados.get("cpf")
     if not nome or not whatsapp or not curso:
         raise HTTPException(400, "Campos obrigatórios ausentes")
+    if cpf and _buscar_aluno_id_por_cpf(cpf):
+        raise HTTPException(409, "CPF já matriculado")
     try:
         token = _obter_token_unidade()
         aluno_id, cpf_res = _cadastrar_aluno_om(


### PR DESCRIPTION
## Resumo
- verifica se o CPF já está matriculado antes de iniciar teste gratuito
- bloqueia novos trials no módulo `trial.py`
- evita criação de assinatura quando o CPF já existe
- impede checkout e assinatura duplicados no `asaas`

## Testes
- `python -m py_compile testegratuito.py trial.py assinantes.py asaas.py`

------
https://chatgpt.com/codex/tasks/task_e_68537d24d40c83269dbd03b9a9e32673