### PR TITLE
Correções na aba Disparos

### DIFF
--- a/disparos_service.py
+++ b/disparos_service.py
@@ -31,8 +31,11 @@ def get_conn():
 @app.route('/grupos')
 def grupos():
     with get_conn() as conn, conn.cursor() as cur:
-        cur.execute('SELECT DISTINCT grupo FROM contatos')
-        grupos = [r[0] for r in cur.fetchall() if r[0]]
+        cur.execute(
+            "SELECT DISTINCT TRIM(grupo) AS grupo "
+            "FROM contatos WHERE grupo IS NOT NULL ORDER BY 1"
+        )
+        grupos = [r[0] for r in cur.fetchall()]
     return jsonify({'grupos': grupos})
 
 

--- a/sistema/index.html
+++ b/sistema/index.html
@@ -1048,8 +1048,9 @@
             async function fetchGrupos() {
                 grupoSelect.innerHTML = '<option value="">Carregando...</option>';
                 try {
-                    const resp = await fetch('https://api.allorigins.win/raw?url=https://whatsapptest-stij.onrender.com/grupos');
+                    const resp = await fetch(`${API_BASE}/grupos`);
                     const data = await resp.json();
+                    data.sort((a, b) => a.nome.localeCompare(b.nome));
                     grupoSelect.innerHTML = '<option value="">Selecione</option>';
                     data.forEach(g => {
                         const opt = document.createElement('option');
@@ -1069,7 +1070,7 @@
                 if (!nome) { leadsTabela.innerHTML = ''; return; }
                 leadsTabela.innerHTML = `<tr><td colspan="2" class="px-6 py-4 text-center"><i class="fas fa-spinner fa-spin text-2xl spotify-green"></i></td></tr>`;
                 try {
-                    const resp = await fetch(`https://api.allorigins.win/raw?url=https://whatsapptest-stij.onrender.com/grupos/${encodeURIComponent(nome)}`);
+                    const resp = await fetch(`${API_BASE}/grupos/${encodeURIComponent(nome)}`);
                     const data = await resp.json();
                     leadsGrupo = data.nome;
                     leadsDados = data.participantes || [];
@@ -1333,15 +1334,18 @@
 
             async function carregarGruposDisparos() {
                 try {
-                    const resp = await fetch('https://api.allorigins.win/raw?url=https://whatsapptest-stij.onrender.com/grupos');
+                    const resp = await fetch(`${API_BASE}/grupos`);
                     const grupos = await resp.json();
-                    dispGrupos.innerHTML = grupos.map(g => `<option value="${g.nome}">${g.nome}</option>`).join('');
+                    grupos.sort((a, b) => a.nome.localeCompare(b.nome));
+                    dispGrupos.innerHTML = '<option value="" disabled>Selecione os grupos</option>' +
+                        grupos.map(g => `<option value="${g.nome}">${g.nome}</option>`).join('');
                 } catch (err) {
                     dispGrupos.innerHTML = '<option>Erro ao carregar</option>';
                 }
             }
 
             async function carregarMensagens() {
+                dispMsgList.innerHTML = '<li>Carregando...</li>';
                 try {
                     const resp = await fetch(`${API_BASE}/mensagens`);
                     const msgs = await resp.json();


### PR DESCRIPTION
## Resumo
- ordena grupos no backend
- usa API_BASE nos carregamentos de grupos
- adiciona opção inicial e ordenação na lista de grupos
- mostra mensagem de carregamento ao buscar mensagens

## Testes
- `python -m py_compile disparos_service.py app/whatsapp.py`

------
https://chatgpt.com/codex/tasks/task_e_6854515215808326a1ca64daba7fc9d3