### PR TITLE
Corrige dependências para importações multipart

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 fastapi
+python-multipart
 uvicorn[standard]
 requests
 flask


### PR DESCRIPTION
## Resumo
- adiciona `python-multipart` ao `requirements.txt`

## Testes
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_6854572f69488326bbc0bba055aae4c0