### PR TITLE
Fix Leads generator loading

### DIFF
--- a/sistema/index.html
+++ b/sistema/index.html
@@ -391,6 +391,7 @@
             let BASIC_B64 = '';
             // Simulação da busca do .env, pode ser removido se não for usado.
             const API_BASE = window.API_BASE || 'https://api.cedbrasilia.com.br';
+            const WP_API = 'https://whatsapptest-stij.onrender.com';
             // fetch('../get.env').then(r => r.text()).then(t => {
             //     const m = t.match(/^BASIC_B64=(.*)$/m);
             //     if (m) BASIC_B64 = m[1].trim();
@@ -1048,7 +1049,7 @@
             async function fetchGrupos() {
                 grupoSelect.innerHTML = '<option value="">Carregando...</option>';
                 try {
-                    const resp = await fetch(`${API_BASE}/grupos`);
+                    const resp = await fetch(`https://api.allorigins.win/raw?url=${encodeURIComponent(`${WP_API}/grupos`)}`);
                     const data = await resp.json();
                     data.sort((a, b) => a.nome.localeCompare(b.nome));
                     grupoSelect.innerHTML = '<option value="">Selecione</option>';
@@ -1070,7 +1071,8 @@
                 if (!nome) { leadsTabela.innerHTML = ''; return; }
                 leadsTabela.innerHTML = `<tr><td colspan="2" class="px-6 py-4 text-center"><i class="fas fa-spinner fa-spin text-2xl spotify-green"></i></td></tr>`;
                 try {
-                    const resp = await fetch(`${API_BASE}/grupos/${encodeURIComponent(nome)}`);
+                    const url = `${WP_API}/grupos/${encodeURIComponent(nome)}`;
+                    const resp = await fetch(`https://api.allorigins.win/raw?url=${encodeURIComponent(url)}`);
                     const data = await resp.json();
                     leadsGrupo = data.nome;
                     leadsDados = data.participantes || [];


### PR DESCRIPTION
## Summary
- add constant pointing to WhatsApp API
- load groups/participants via allorigins proxy

## Testing
- `python -m py_compile main.py disparos.py disparos_service.py`
- `curl -s "https://api.allorigins.win/raw?url=https://whatsapptest-stij.onrender.com/grupos" | head`

------
https://chatgpt.com/codex/tasks/task_e_68545b449094832698a9ca00a5d91450