### PR TITLE
Corrige validacao de numeros WhatsApp

### DIFF
--- a/disparos.py
+++ b/disparos.py
@@ -203,11 +203,9 @@ def save_history(hist):
 
 
 def is_on_whatsapp(numero: str) -> bool:
-    try:
-        parsed = phonenumbers.parse('+' + numero, None)
-        if not phonenumbers.is_possible_number(parsed):
-            return False
-    except Exception:
+    """Verifica o formato e simula checagem no WhatsApp."""
+    digitos = "".join(filter(str.isdigit, numero or ""))
+    if not digitos.startswith("55") or len(digitos) != 12:
         return False
     return random.random() > 0.05
 

--- a/disparos_service.py
+++ b/disparos_service.py
@@ -159,12 +159,9 @@ def save_history(hist):
 
 
 def is_on_whatsapp(numero: str) -> bool:
-    """Verifica formato válido e simula checagem no WhatsApp."""
-    try:
-        parsed = phonenumbers.parse("+" + numero, None)
-        if not phonenumbers.is_possible_number(parsed):
-            return False
-    except Exception:
+    """Verifica o formato e simula checagem no WhatsApp."""
+    digitos = "".join(filter(str.isdigit, numero or ""))
+    if not digitos.startswith("55") or len(digitos) != 12:
         return False
     # Simula 5% de números não encontrados no WhatsApp
     return random.random() > 0.05

--- a/utils.py
+++ b/utils.py
@@ -12,13 +12,19 @@ def formatar_numero_whatsapp(numero: str) -> str:
     # Extrai apenas os dígitos informados
     digitos = "".join(filter(str.isdigit, numero or ""))
 
-    # Remove prefixo Brasil caso já esteja presente
-    if digitos.startswith("55"):
-        digitos = digitos[2:]
+    if not digitos:
+        return ""
 
-    # Remove o nono dígito (ex.: 61912345678 -> 6112345678)
-    if len(digitos) >= 11 and digitos[2] == "9":
-        digitos = digitos[:2] + digitos[3:]
+    if digitos.startswith("55"):
+        # Remove prefixo Brasil caso já esteja presente
+        digitos = digitos[2:]
+        # Remove o nono dígito após o DDD, se houver
+        if len(digitos) >= 10 and digitos[2] == "9":
+            digitos = digitos[:2] + digitos[3:]
+    else:
+        # Números locais devem conter o nono dígito
+        if len(digitos) == 10:
+            digitos = digitos[:2] + "9" + digitos[2:]
 
     return "55" + digitos
 


### PR DESCRIPTION
## Summary
- ajuste de `formatar_numero_whatsapp` para incluir/remover nono dígito conforme regra
- simplificação da função `is_on_whatsapp`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6854693d883c83268a250c61ca2b6a5f