### PR TITLE
Adiciona página de grupos e melhorias

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@ PG_PORT=5432
 PG_DB=ced
 PG_USER=ced
 PG_PASS=ced
+SQLITE_DB=local.db

--- a/AGENTE.txt
+++ b/AGENTE.txt
@@ -28,3 +28,8 @@ PR #6 - Redireciona menu Disparos para /sistema/disparo
 PR #7 - Corrige acesso sem barra final a /sistema/disparo e atualiza menu
 
 PR #8 - Corrige 404 em /sistema/disparo ordenando mounts
+PR #9 - Ajustes em listas e página de grupos
+- Novo fallback para SQLite em backend/app/models.py
+- Interface de disparos agora usa Tailwind e favicon padrão
+- Adicionado menu "Grupos" com listagem de participantes e exportação
+- Script aprimorado com tratamento de erros e suporte a uploads

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -9,7 +9,12 @@ PG_DB = os.getenv('PG_DB')
 PG_USER = os.getenv('PG_USER')
 PG_PASS = os.getenv('PG_PASS')
 
-DB_URL = f"postgresql+asyncpg://{PG_USER}:{PG_PASS}@{PG_HOST}:{PG_PORT}/{PG_DB}"
+if PG_HOST:
+    DB_URL = f"postgresql+asyncpg://{PG_USER}:{PG_PASS}@{PG_HOST}:{PG_PORT}/{PG_DB}"
+else:
+    sqlite_path = os.getenv('SQLITE_DB', 'local.db')
+    DB_URL = f"sqlite+aiosqlite:///{sqlite_path}"
+
 engine = create_async_engine(DB_URL, future=True, echo=False)
 AsyncSessionLocal = sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,9 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Disparos - Sistema</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
+    <link rel="icon" href="/favicon.jpg" type="image/jpeg" />
     <style>
         :root {
             --bg-dark-primary: #121212;
@@ -111,6 +112,7 @@
         <a href="#" class="vertical-nav-link" data-page="page-messages">Mensagens</a>
         <a href="#" class="vertical-nav-link" data-page="page-broadcast">Disparo de Mensagem</a>
         <a href="#" class="vertical-nav-link" data-page="page-files">Meus Arquivos</a>
+        <a href="#" class="vertical-nav-link" data-page="page-groups">Grupos</a>
     </nav>
     <main class="main-content">
         <div id="page-contact-lists" class="page active">
@@ -171,6 +173,27 @@
                     <p>Arraste e solte arquivos aqui ou clique para selecionar</p>
                     <input type="file" multiple id="file-upload" style="display:none;">
                 </div>
+            </div>
+        </div>
+        <div id="page-groups" class="page">
+            <div class="page-header">
+                <h1>Grupos</h1>
+            </div>
+            <div class="form-container" style="max-width:400px;">
+                <label for="groups-select">Grupo</label>
+                <select id="groups-select"></select>
+            </div>
+            <div class="data-table-container" style="margin-top:20px;">
+                <table class="data-table">
+                    <thead>
+                        <tr><th>Número</th><th>Admin</th></tr>
+                    </thead>
+                    <tbody id="tbody-grupo"></tbody>
+                </table>
+            </div>
+            <div style="margin-top:15px;text-align:center;">
+                <button class="btn btn-primary" id="btn-export-csv">Exportar CSV</button>
+                <button class="btn btn-primary" id="btn-export-xlsx">Exportar XLSX</button>
             </div>
         </div>
         <div id="page-add-contacts" class="page">
@@ -256,6 +279,7 @@
             </div>
         </div>
     </main>
+    <script src="/libs/xlsx.full.min.js"></script>
     <script src="script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Resumo
- incluir fallback para banco SQLite
- adicionar favicon e Tailwind na interface de disparos
- criar menu e página "Grupos" com exportação de números
- aprimorar script JS com tratamento de erros e suporte a uploads
- registrar PR na memória

## Testes
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854b32644008326a7e68a08c3954f9d