### PR TITLE
Adicionar script PHP para disparos

### DIFF
--- a/AGENTE.txt
+++ b/AGENTE.txt
@@ -55,3 +55,4 @@ PR #15 - Configuração de API base
 - script.js passa a usar window.API_BASE como base da API.
 PR #16 - Ferramenta CLI de administração do banco
 - Criado db_admin.py com comandos init-db, add-lista, list-listas, add-contato e list-contatos
+PR #17 - Script PHP para disparos

--- a/README.md
+++ b/README.md
@@ -43,3 +43,12 @@ curl -X POST http://localhost:8000/api/mensagens -H 'Content-Type: application/j
 ```bash
 curl -X POST http://localhost:8000/api/disparos -H 'Content-Type: application/json' -d '{"lista_id":1,"mensagem_id":1}'
 ```
+
+### CLI em PHP
+Para casos de teste ou integração rápida, o projeto inclui `php/disparos.php`. O script permite criar e listar disparos diretamente no banco PostgreSQL usando variáveis de ambiente. Exemplos de uso:
+
+```bash
+php php/disparos.php create 1 2 "2025-07-01 10:00:00"
+php php/disparos.php list
+```
+

--- a/php/disparos.php
+++ b/php/disparos.php
@@ -1,0 +1,38 @@
+<?php
+// Ferramenta simples para manipular a tabela de disparos via CLI
+// Usa variaveis de ambiente para se conectar ao PostgreSQL
+
+$host = getenv('PG_HOST') ?: 'localhost';
+$port = getenv('PG_PORT') ?: '5432';
+$db   = getenv('PG_DB')   ?: 'ced';
+$user = getenv('PG_USER') ?: 'ced';
+$pass = getenv('PG_PASS') ?: 'ced';
+
+$dsn = "pgsql:host=$host;port=$port;dbname=$db";
+$options = [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION];
+$pdo = new PDO($dsn, $user, $pass, $options);
+
+$acao = $argv[1] ?? '';
+if ($acao === 'create') {
+    $lista    = isset($argv[2]) ? (int)$argv[2] : 0;
+    $mensagem = isset($argv[3]) ? (int)$argv[3] : 0;
+    $agendado = $argv[4] ?? null;
+    if (!$lista || !$mensagem) {
+        fwrite(STDERR, "Uso: php disparos.php create <lista_id> <mensagem_id> [agendado_para]\n");
+        exit(1);
+    }
+    $stmt = $pdo->prepare('INSERT INTO disparos (lista_id, mensagem_id, agendado_para) VALUES (:lista, :msg, :ag) RETURNING id');
+    $stmt->execute([':lista' => $lista, ':msg' => $mensagem, ':ag' => $agendado]);
+    $id = $stmt->fetchColumn();
+    echo "Disparo criado com ID {$id}\n";
+} elseif ($acao === 'list') {
+    foreach ($pdo->query('SELECT id, lista_id, mensagem_id, agendado_para, status, criado_em FROM disparos ORDER BY id') as $row) {
+        echo json_encode($row, JSON_UNESCAPED_UNICODE) . PHP_EOL;
+    }
+} else {
+    echo "Uso:\n";
+    echo "  php disparos.php create <lista_id> <mensagem_id> [agendado_para]\n";
+    echo "  php disparos.php list\n";
+}
+?>
+


### PR DESCRIPTION
## Summary
- implementar `php/disparos.php` para manipular a tabela de disparos usando variáveis de ambiente
- documentar o uso do script no README
- registrar memória no AGENTE.txt

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `php -l php/disparos.php` *(falhou: comando não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_6854c7c0de48832697ca5fc26f402391