### PR TITLE
Implementa importação por grupo e cache de mensagens

### DIFF
--- a/AGENTE.txt
+++ b/AGENTE.txt
@@ -57,3 +57,4 @@ PR #16 - Ferramenta CLI de administração do banco
 - Criado db_admin.py com comandos init-db, add-lista, list-listas, add-contato e list-contatos
 PR #17 - Script PHP para disparos
 PR #18 - Atalho para /disparos
+PR #19 - Abas de contatos por grupo e cache de mensagens

--- a/backend/app/routers/contatos.py
+++ b/backend/app/routers/contatos.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, UploadFile, File
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, File, Body
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 import pandas as pd
@@ -77,6 +77,21 @@ async def importar(lista_id: int, file: UploadFile = File(...), db: AsyncSession
             desc2=row.get("desc2"),
             desc3=row.get("desc3"),
         )
+        db.add(contato)
+        total += 1
+    await db.commit()
+    return {"importados": total}
+
+
+@router.post("/adicionar_numeros/{lista_id}", response_model=dict)
+async def adicionar_numeros(lista_id: int, numeros: list[str] = Body(...), db: AsyncSession = Depends(get_db)):
+    """Adiciona uma lista de números simples à lista informada."""
+    total = 0
+    for num in numeros:
+        telefone = str(num).strip()
+        if not telefone:
+            continue
+        contato = Contato(lista_id=lista_id, telefone=telefone)
         db.add(contato)
         total += 1
     await db.commit()

--- a/backend/app/routers/mensagens.py
+++ b/backend/app/routers/mensagens.py
@@ -1,52 +1,73 @@
-from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
+import json
+import os
+from datetime import datetime
+from fastapi import APIRouter, HTTPException
 
-from ..models import AsyncSessionLocal, Mensagem
 from ..schemas import Mensagem as MensagemSchema, MensagemCreate
 
 router = APIRouter(prefix="/api/mensagens", tags=["Mensagens"])
 
-async def get_db():
-    async with AsyncSessionLocal() as session:
-        yield session
+CACHE_FILE = os.path.join(os.path.dirname(__file__), '..', 'mensagens_cache.json')
+
+
+def _load() -> list[dict]:
+    try:
+        with open(CACHE_FILE, 'r') as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return []
+
+
+def _save(data: list[dict]):
+    with open(CACHE_FILE, 'w') as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+
+def _next_id(data: list[dict]) -> int:
+    return max([m.get('id', 0) for m in data] or [0]) + 1
+
 
 @router.post("", response_model=MensagemSchema)
-async def criar(dados: MensagemCreate, db: AsyncSession = Depends(get_db)):
-    msg = Mensagem(**dados.dict())
-    db.add(msg)
-    await db.commit()
-    await db.refresh(msg)
-    return msg
+async def criar(dados: MensagemCreate):
+    msgs = _load()
+    item = dados.dict()
+    item['id'] = _next_id(msgs)
+    item['criado_em'] = datetime.utcnow().isoformat()
+    msgs.append(item)
+    _save(msgs)
+    return item
+
 
 @router.get("", response_model=list[MensagemSchema])
-async def listar(db: AsyncSession = Depends(get_db)):
-    res = await db.execute(select(Mensagem))
-    return res.scalars().all()
+async def listar():
+    return _load()
+
 
 @router.get("/{mid}", response_model=MensagemSchema)
-async def detalhe(mid: int, db: AsyncSession = Depends(get_db)):
-    msg = await db.get(Mensagem, mid)
-    if not msg:
-        raise HTTPException(404)
-    return msg
+async def detalhe(mid: int):
+    msgs = _load()
+    for m in msgs:
+        if m['id'] == mid:
+            return m
+    raise HTTPException(404)
+
 
 @router.put("/{mid}", response_model=MensagemSchema)
-async def atualizar(mid: int, dados: MensagemCreate, db: AsyncSession = Depends(get_db)):
-    msg = await db.get(Mensagem, mid)
-    if not msg:
-        raise HTTPException(404)
-    for k, v in dados.dict().items():
-        setattr(msg, k, v)
-    await db.commit()
-    await db.refresh(msg)
-    return msg
+async def atualizar(mid: int, dados: MensagemCreate):
+    msgs = _load()
+    for m in msgs:
+        if m['id'] == mid:
+            m.update(dados.dict())
+            _save(msgs)
+            return m
+    raise HTTPException(404)
+
 
 @router.delete("/{mid}")
-async def remover(mid: int, db: AsyncSession = Depends(get_db)):
-    msg = await db.get(Mensagem, mid)
-    if not msg:
+async def remover(mid: int):
+    msgs = _load()
+    new_msgs = [m for m in msgs if m['id'] != mid]
+    if len(new_msgs) == len(msgs):
         raise HTTPException(404)
-    await db.delete(msg)
-    await db.commit()
+    _save(new_msgs)
     return {"ok": True}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -209,6 +209,7 @@
                 <div class="add-contacts-tabs">
                     <button class="add-contacts-tab-link active" data-tab="manual">Adicionar Manualmente</button>
                     <button class="add-contacts-tab-link" data-tab="upload">Fazer Upload</button>
+                    <button class="add-contacts-tab-link" data-tab="grupo">Do Grupo</button>
                 </div>
                 <div id="manual" class="tab-content active">
                     <div class="form-group">
@@ -233,6 +234,19 @@
                     <div class="form-group"><label for="col-desc2">Descrição 2</label><select id="col-desc2"></select></div>
                     <div class="form-group"><label for="col-desc3">Descrição 3</label><select id="col-desc3"></select></div>
                     <button class="btn btn-primary" id="btn-import-contatos">Importar Contatos</button>
+                </div>
+                <div id="grupo" class="tab-content">
+                    <div class="form-group">
+                        <label for="groups-select-add">Grupo</label>
+                        <select id="groups-select-add"></select>
+                    </div>
+                    <div class="data-table-container" style="margin-top:10px;">
+                        <table class="data-table">
+                            <thead><tr><th>Número</th><th>Admin</th></tr></thead>
+                            <tbody id="tbody-grupo-add"></tbody>
+                        </table>
+                    </div>
+                    <button class="btn btn-primary" id="btn-add-from-group" style="margin-top:15px;">Adicionar Números</button>
                 </div>
             </div>
         </div>

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -121,8 +121,8 @@ let currentMsgId = null;
 let gruposDados = [];
 let gruposNome = '';
 
-async function carregarGrupos(){
-    const sel = document.getElementById('groups-select');
+async function carregarGrupos(elId='groups-select'){
+    const sel = document.getElementById(elId);
     sel.innerHTML = '<option>Carregando...</option>';
     try{
         const data = await fetchJSON('/grupos');
@@ -140,8 +140,8 @@ async function carregarGrupos(){
     }
 }
 
-async function carregarParticipantes(nome){
-    const tbody = document.getElementById('tbody-grupo');
+async function carregarParticipantes(nome, tbodyId='tbody-grupo'){
+    const tbody = document.getElementById(tbodyId);
     if(!nome){ tbody.innerHTML = ''; return; }
     tbody.innerHTML = '<tr><td colspan="2" style="text-align:center">Carregando...</td></tr>';
     try{
@@ -285,6 +285,37 @@ document.addEventListener('DOMContentLoaded', ()=>{
         e.target.value='';
         alert('Contatos importados com sucesso');
     });
+
+    document.querySelectorAll('.add-contacts-tab-link').forEach(btn=>{
+        btn.addEventListener('click',()=>{
+            document.querySelectorAll('.add-contacts-tab-link').forEach(b=>b.classList.remove('active'));
+            document.querySelectorAll('#page-add-contacts .tab-content').forEach(tc=>tc.classList.remove('active'));
+            btn.classList.add('active');
+            document.getElementById(btn.dataset.tab).classList.add('active');
+        });
+    });
+
+    const grpAdd = document.getElementById('groups-select-add');
+    if(grpAdd){
+        carregarGrupos('groups-select-add');
+        grpAdd.addEventListener('change',e=>carregarParticipantes(e.target.value,'tbody-grupo-add'));
+    }
+    const btnAddGrupo = document.getElementById('btn-add-from-group');
+    if(btnAddGrupo){
+        btnAddGrupo.addEventListener('click',async()=>{
+            const nome = document.getElementById('groups-select-add').value;
+            if(!nome || !currentListId) return;
+            const data = await fetchJSON(`/grupos/${encodeURIComponent(nome)}`);
+            const numeros = (data.participantes||[]).map(p=>p.numero);
+            if(numeros.length){
+                await fetch(`${api}/contatos/adicionar_numeros/${currentListId}`,{
+                    method:'POST',headers:{'Content-Type':'application/json'},
+                    body:JSON.stringify(numeros)
+                });
+                alert('Números adicionados');
+            }
+        });
+    }
 
     const grpSel = document.getElementById('groups-select');
     if(grpSel){


### PR DESCRIPTION
## Resumo
- permite adicionar números de grupos às listas de contatos
- adiciona nova aba no frontend para importar contatos de grupos
- implementa nova rota `/adicionar_numeros` no backend
- armazena mensagens em arquivo JSON em vez de banco de dados
- registra histórico da mudança em `AGENTE.txt`

## Testes
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854cee097508326ae1b85995febd8d4