### PR TITLE
Implementa contagem de contatos nos disparos

### DIFF
--- a/AGENTE.txt
+++ b/AGENTE.txt
@@ -62,3 +62,6 @@ PR #20 - Página /sistema/disparo removida
 - Integração volta para seção Disparos dentro de sistema/index.html
 - Rotas /sistema/disparo e /disparos removidas de main.py e backend
 - README atualizado com novo caminho da interface
+PR #21 - Contagem de participantes nos grupos de disparo
+- Endpoint /grupos/<nome> retorna participantes e quantidade
+- Interface exibe contagem ao selecionar grupos

--- a/disparos_service.py
+++ b/disparos_service.py
@@ -67,6 +67,17 @@ def grupos():
     return jsonify({'grupos': grupos})
 
 
+@app.route('/grupos/<string:nome>')
+def grupo_detalhe(nome: str):
+    """Retorna participantes de um grupo específico."""
+    participantes = buscar_numeros_do_grupo(nome)
+    return jsonify({
+        'nome': nome,
+        'quantidade': len(participantes),
+        'participantes': [{'numero': n} for n in participantes]
+    })
+
+
 @app.route('/mensagens', methods=['GET', 'POST'])
 def mensagens():
     if request.method == 'POST':

--- a/sistema/index.html
+++ b/sistema/index.html
@@ -1342,12 +1342,33 @@
                 }
             }
 
+            async function obterQtdGrupo(nome) {
+                try {
+                    const url = `${WP_API}/grupos/${encodeURIComponent(nome)}`;
+                    const r = await fetch(`https://api.allorigins.win/raw?url=${encodeURIComponent(url)}`);
+                    const d = await r.json();
+                    return (d.participantes || []).length;
+                } catch {
+                    return 0;
+                }
+            }
+
             async function carregarGruposDisparos() {
                 try {
                     const resp = await fetch(`https://api.allorigins.win/raw?url=${encodeURIComponent(`${WP_API}/grupos`)}`);
                     const grupos = await resp.json();
                     grupos.sort((a, b) => a.nome.localeCompare(b.nome));
-                    dispGrupos.innerHTML = grupos.map(g => `<label class="flex items-center gap-2"><input type="checkbox" value="${g.nome}" class="disp-grupo">${g.nome}</label>`).join('');
+                    dispGrupos.innerHTML = grupos.map(g => `<label class="flex items-center gap-2"><input type="checkbox" value="${g.nome}" class="disp-grupo"><span>${g.nome}</span> <span class="count text-xs text-gray-500"></span></label>`).join('');
+                    dispGrupos.querySelectorAll('.disp-grupo').forEach(cb => {
+                        cb.addEventListener('change', async () => {
+                            const span = cb.parentElement.querySelector('.count');
+                            if (cb.checked && !span.textContent) {
+                                span.textContent = '...';
+                                const qtd = await obterQtdGrupo(cb.value);
+                                span.textContent = `(${qtd})`;
+                            }
+                        });
+                    });
                 } catch (err) {
                     dispGrupos.innerHTML = '<p>Erro ao carregar</p>';
                 }


### PR DESCRIPTION
## Summary
- exibir quantidade de participantes ao selecionar grupos
- disponibilizar endpoint `/grupos/<nome>` no disparos_service
- registrar mudança em AGENTE.txt

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855a745462c8326b806e48abe318755