### PR TITLE
Persist WhatsApp auth between restarts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,4 @@ PG_USER=ced
 PG_PASS=ced
 WP_API=http://whatsapp:3000
 WHATSAPP_URL=http://whatsapp:3000/send
+WHATSAPP_AUTH_DIR=/data

--- a/AGENTE.txt
+++ b/AGENTE.txt
@@ -71,3 +71,8 @@ PR #23 - Integra serviço WhatsApp em Node
 - Dockerfile adicionado em API WHATSAPP e serviço "whatsapp" no compose
 - Variáveis WP_API e WHATSAPP_URL no .env.example
 - READMEs removidos conforme instruções
+
+PR #24 - Persistência das credenciais do WhatsApp
+- index.js permite configurar pasta via WHATSAPP_AUTH_DIR
+- docker-compose monta volume whatsapp_auth em /data
+- .env.example define variável WHATSAPP_AUTH_DIR=/data

--- a/API WHATSAPP/index.js
+++ b/API WHATSAPP/index.js
@@ -11,6 +11,7 @@ const path = require('path');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
+const AUTH_DIR = process.env.WHATSAPP_AUTH_DIR || 'auth_info_baileys';
 let sock = null;
 let qrCodeBase64 = null;
 const NUMBERS_FILE = 'numbers.json';
@@ -198,7 +199,7 @@ app.head('/secure', (_, res) => {
 });
 
 async function startBot() {
-  const { state, saveCreds } = await useMultiFileAuthState('auth_info_baileys');
+  const { state, saveCreds } = await useMultiFileAuthState(AUTH_DIR);
   sock = makeWASocket({ auth: state, printQRInTerminal: false });
 
   sock.ev.on('creds.update', saveCreds);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,11 @@ services:
     build: ./API WHATSAPP
     environment:
       - PORT=3000
+      - WHATSAPP_AUTH_DIR=/data
     ports:
       - "3000:3000"
+    volumes:
+      - whatsapp_auth:/data
 volumes:
   pgdata:
+  whatsapp_auth:


### PR DESCRIPTION
## Summary
- allow configuring Baileys auth directory via `WHATSAPP_AUTH_DIR`
- mount `/data` volume for the WhatsApp service
- document new variable in `.env.example`
- log PR in `AGENTE.txt`

## Testing
- `npm install`
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_6855b88649cc832689becd37dd4810ab