### PR TITLE
Fix QR code fetch logic

### DIFF
--- a/AGENTE.txt
+++ b/AGENTE.txt
@@ -90,3 +90,4 @@ PR #27 - Atualiza domínio do serviço WhatsApp e melhoria no QR
 
 PR #28 - Fallback de QR e novo endpoint
 PR #29 - Remove fallback QR generation and /qr/raw endpoint
+PR #30 - Corrige endpoint do QR e parsing

--- a/main.py
+++ b/main.py
@@ -8,7 +8,9 @@ import re
 
 from log_config import setup_logging, send_startup_message
 
-WP_API = os.getenv("WP_API", "https://api.cedbrasilia.com.br")
+# endereço do serviço Node que gera o QR do WhatsApp
+# por padrão aponta para a porta local usada no docker-compose
+WP_API = os.getenv("WP_API", "http://localhost:3000")
 
 setup_logging()
 
@@ -132,7 +134,13 @@ def qr_data():
             pass
         resp = requests.get(f"{WP_API}/qr", timeout=10)
         if resp.ok:
-            m = re.search(r'src="([^"]+)"', resp.text)
+            try:
+                data = resp.json()
+                if isinstance(data, dict) and data.get("qr"):
+                    return {"qr": data["qr"]}
+            except Exception:
+                pass
+            m = re.search(r'src="(data:[^"]+)"', resp.text)
             if m:
                 return {"qr": m.group(1)}
     except Exception:


### PR DESCRIPTION
## Summary
- fetch QR code from Node service on localhost by default
- improve parsing of /qr response to accept JSON or data URL
- note change in AGENTE.txt

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6855c6d7ad848326b00d5f82647d22a3