### PR TITLE
Fix default WP_API

### DIFF
--- a/AGENTE.txt
+++ b/AGENTE.txt
@@ -91,3 +91,4 @@ PR #27 - Atualiza domínio do serviço WhatsApp e melhoria no QR
 PR #28 - Fallback de QR e novo endpoint
 PR #29 - Remove fallback QR generation and /qr/raw endpoint
 PR #30 - Corrige endpoint do QR e parsing
+PR #31 - Ajusta WP_API para dominio api.cedbrasilia.com.br por padrao

--- a/main.py
+++ b/main.py
@@ -9,8 +9,8 @@ import re
 from log_config import setup_logging, send_startup_message
 
 # endereço do serviço Node que gera o QR do WhatsApp
-# por padrão aponta para a porta local usada no docker-compose
-WP_API = os.getenv("WP_API", "http://localhost:3000")
+# por padrão usa o domínio oficial em produção
+WP_API = os.getenv("WP_API", "https://api.cedbrasilia.com.br")
 
 setup_logging()
 


### PR DESCRIPTION
## Summary
- fix default WP_API so `/qr` can pull from api.cedbrasilia.com.br
- update memory in AGENTE.txt

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6855c8a2c2fc83268839b270337e77f8