### PR TITLE
Fix QR endpoint fetch

### DIFF
--- a/AGENTE.txt
+++ b/AGENTE.txt
@@ -92,3 +92,4 @@ PR #28 - Fallback de QR e novo endpoint
 PR #29 - Remove fallback QR generation and /qr/raw endpoint
 PR #30 - Corrige endpoint do QR e parsing
 PR #31 - Ajusta WP_API para dominio api.cedbrasilia.com.br por padrao
+PR #32 - Ajusta QR usando WP_API_QR com porta padrao 3000

--- a/main.py
+++ b/main.py
@@ -11,6 +11,8 @@ from log_config import setup_logging, send_startup_message
 # endereço do serviço Node que gera o QR do WhatsApp
 # por padrão usa o domínio oficial em produção
 WP_API = os.getenv("WP_API", "https://api.cedbrasilia.com.br")
+# para buscar o QR diretamente no serviço, permite definir uma porta
+WP_API_QR = os.getenv("WP_API_QR", f"{WP_API}:3000")
 
 setup_logging()
 
@@ -129,10 +131,10 @@ def qr_data():
     """Busca o QR Code atualizado na API externa."""
     try:
         try:
-            requests.post(f"{WP_API}/connect", timeout=5)
+            requests.post(f"{WP_API_QR}/connect", timeout=5)
         except Exception:
             pass
-        resp = requests.get(f"{WP_API}/qr", timeout=10)
+        resp = requests.get(f"{WP_API_QR}/qr", timeout=10)
         if resp.ok:
             try:
                 data = resp.json()


### PR DESCRIPTION
## Summary
- use `WP_API_QR` with default port 3000 for WhatsApp service
- log update in AGENTE.txt

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6855caf6f8a88326ab120072f3964a03