### PR TITLE
Remove grid background overlay

### DIFF
--- a/Memoria.txt
+++ b/Memoria.txt
@@ -1,0 +1,2 @@
+Usuario solicitou: "remove o fundo de grade de todas as abas".
+O agente removeu o CSS que adicionava uma grade de fundo em todos os arquivos HTML e no style.css.

--- a/assinatura.html
+++ b/assinatura.html
@@ -32,20 +32,7 @@
             position: relative;
         }
 
-        body::before {
-            content: "";
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            background-image:
-                linear-gradient(to right, rgba(255, 255, 255, 0.05) 1px, transparent 1px),
-                linear-gradient(to bottom, rgba(255, 255, 255, 0.05) 1px, transparent 1px);
-            background-size: 40px 40px;
-            z-index: -2;
-            pointer-events: none;
-        }
+
 
         h1, h2, h3, h4, h5, h6 {
             font-family: 'Poppins', sans-serif;

--- a/index.html
+++ b/index.html
@@ -44,20 +44,7 @@
             transition: background-color 0.3s ease, color 0.3s ease;
         }
         
-        body::before {
-            content: "";
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100vw;
-            height: 100vh;
-            background-image:
-                linear-gradient(to right, rgba(119, 119, 119, 0.1) 1px, transparent 1px),
-                linear-gradient(to bottom, rgba(119, 119, 119, 0.1) 1px, transparent 1px);
-            background-size: 40px 40px;
-            z-index: -2;
-            pointer-events: none;
-        }
+
 
         .logo-text { color: var(--logo-text-color); }
         .subscription-box { background-color: var(--subscription-box-bg); }

--- a/sistema/index.html
+++ b/sistema/index.html
@@ -16,20 +16,7 @@
             position: relative;
         }
 
-        body::before {
-            content: "";
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100vw;
-            height: 100vh;
-            background-image:
-                linear-gradient(to right, rgba(255, 255, 255, 0.05) 1px, transparent 1px),
-                linear-gradient(to bottom, rgba(255, 255, 255, 0.05) 1px, transparent 1px);
-            background-size: 40px 40px;
-            z-index: -2;
-            pointer-events: none;
-        }
+
 
         h1, h2, h3, h4, h5, h6 {
             font-family: 'Poppins', sans-serif;

--- a/style.css
+++ b/style.css
@@ -32,20 +32,7 @@
             transition: background-color 0.3s ease, color 0.3s ease;
         }
         
-        body::before {
-            content: "";
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100vw;
-            height: 100vh;
-            background-image:
-                linear-gradient(to right, rgba(119, 119, 119, 0.1) 1px, transparent 1px),
-                linear-gradient(to bottom, rgba(119, 119, 119, 0.1) 1px, transparent 1px);
-            background-size: 40px 40px;
-            z-index: -2;
-            pointer-events: none;
-        }
+
 
         body::after {
             content: "";


### PR DESCRIPTION
## Summary
- remove CSS grid overlay from all pages
- save conversation memory to Memoria.txt

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bd4d02f008326a1e542d567ac6332