### PR TITLE
Atualiza preços dos cursos para R$19,90

### DIFF
--- a/Memoria.txt
+++ b/Memoria.txt
@@ -1,2 +1,3 @@
 Usuario solicitou: "remove o fundo de grade de todas as abas".
 O agente removeu o CSS que adicionava uma grade de fundo em todos os arquivos HTML e no style.css.
+Usuario solicitou: "Mude o preço de todos os cursos para 19,90 e troque o botão teste grátis por Me matricular agora". O agente atualizou os preços nos arquivos HTML e JS para R$ 19,90 e alterou o texto do botão conforme solicitado.

--- a/afiliados.html
+++ b/afiliados.html
@@ -278,17 +278,17 @@
         
         // Populate Products Table
         const products = [
-            { name: "Administração", price: "59,90" },
-            { name: "Análise e Desenvolvimento de Sistemas", price: "89,90" },
-            { name: "Excel PRO", price: "59,90" },
-            { name: "Inglês Kids", price: "49,90" },
-            { name: "Informática Essencial", price: "59,90" },
-            { name: "Marketing Digital", price: "99,90" },
-            { name: "Inglês Fluente", price: "109,90" },
-            { name: "Design Gráfico", price: "99,90" },
-            { name: "Operador de Micro", price: "69,90" },
-            { name: "Pacote Office", price: "39,99" },
-            { name: "Especialista em Marketing & Vendas 360º", price: "159,90" },
+            { name: "Administração", price: "19,90" },
+            { name: "Análise e Desenvolvimento de Sistemas", price: "19,90" },
+            { name: "Excel PRO", price: "19,90" },
+            { name: "Inglês Kids", price: "19,90" },
+            { name: "Informática Essencial", price: "19,90" },
+            { name: "Marketing Digital", price: "19,90" },
+            { name: "Inglês Fluente", price: "19,90" },
+            { name: "Design Gráfico", price: "19,90" },
+            { name: "Operador de Micro", price: "19,90" },
+            { name: "Pacote Office", price: "19,90" },
+            { name: "Especialista em Marketing & Vendas 360º", price: "19,90" },
         ];
 
         const tableBody = document.querySelector('table tbody');

--- a/conectar_site_com_asaas.js
+++ b/conectar_site_com_asaas.js
@@ -25,7 +25,7 @@ const dados = {
   nome: 'Maria',
   cpf: '12345678909',
   whatsapp: '(61) 99999-9999',
-  valor: 29.9,
+  valor: 19.9,
   descricao: 'Pacote Office',
   cursos_ids: [130]
 };

--- a/course-form.js
+++ b/course-form.js
@@ -1,15 +1,15 @@
 const COURSE_PRICES = {
-  "Excel PRO": 49.90,
-  "Design Gráfico": 89.90,
-  "Analista e Desenvolvimento de Sistemas": 79.90,
-  "Administração": 49.90,
-  "Inglês Fluente": 99.90,
-  "Inglês Kids": 39.90,
-  "Informática Essencial": 49.90,
-  "Operador de Micro": 59.90,
-  "Especialista em Marketing & Vendas 360º": 149.90,
-  "Marketing Digital": 89.90,
-  "Pacote Office": 29.99,
+  "Excel PRO": 19.90,
+  "Design Gráfico": 19.90,
+  "Analista e Desenvolvimento de Sistemas": 19.90,
+  "Administração": 19.90,
+  "Inglês Fluente": 19.90,
+  "Inglês Kids": 19.90,
+  "Informática Essencial": 19.90,
+  "Operador de Micro": 19.90,
+  "Especialista em Marketing & Vendas 360º": 19.90,
+  "Marketing Digital": 19.90,
+  "Pacote Office": 19.90,
 };
 
 function applyCPFMask(v) {

--- a/index.html
+++ b/index.html
@@ -725,17 +725,17 @@
     <script>
 
         const COURSE_PRICES = {
-            "Excel PRO": 49.90,
-            "Design Gráfico": 89.90,
-            "Analista e Desenvolvimento de Sistemas": 79.90,
-            "Administração": 49.90,
-            "Inglês Fluente": 99.90,
-            "Inglês Kids": 39.90,
-            "Informática Essencial": 49.90,
-            "Operador de Micro": 59.90,
-            "Especialista em Marketing & Vendas 360º": 149.90,
-            "Marketing Digital": 89.90,
-            "Pacote Office": 29.99,
+            "Excel PRO": 19.90,
+            "Design Gráfico": 19.90,
+            "Analista e Desenvolvimento de Sistemas": 19.90,
+            "Administração": 19.90,
+            "Inglês Fluente": 19.90,
+            "Inglês Kids": 19.90,
+            "Informática Essencial": 19.90,
+            "Operador de Micro": 19.90,
+            "Especialista em Marketing & Vendas 360º": 19.90,
+            "Marketing Digital": 19.90,
+            "Pacote Office": 19.90,
         };
 
         const COURSE_DESCRIPTIONS = {
@@ -837,7 +837,7 @@
                             <span class="preco-novo">R$ 0,00</span>
                             <span class="text-muted text-xs block">3 dias de teste</span>
                         </div>
-                        <button class="trial-course button-glow bg-blue-600 text-white font-semibold py-2 px-4 rounded-full transition-all duration-300" data-course-name="${course.name}">Teste grátis</button>
+                        <button class="trial-course button-glow bg-blue-600 text-white font-semibold py-2 px-4 rounded-full transition-all duration-300" data-course-name="${course.name}">Me matricular agora!</button>
                     </div>
                 `;
                 courseList.appendChild(courseCard);
@@ -1315,17 +1315,17 @@
             
             function loadAfiliadosProducts() {
                 const afiliadosProducts = [
-                    { name: "Administração", price: "59,90" },
-                    { name: "Análise e Desenvolvimento de Sistemas", price: "89,90" },
-                    { name: "Excel PRO", price: "59,90" },
-                    { name: "Inglês Kids", price: "49,90" },
-                    { name: "Informática Essencial", price: "59,90" },
-                    { name: "Marketing Digital", price: "99,90" },
-                    { name: "Inglês Fluente", price: "109,90" },
-                    { name: "Design Gráfico", price: "99,90" },
-                    { name: "Operador de Micro", price: "69,90" },
-                    { name: "Pacote Office", price: "39,99" },
-                    { name: "Especialista em Marketing & Vendas 360º", price: "159,90" },
+                    { name: "Administração", price: "19,90" },
+                    { name: "Análise e Desenvolvimento de Sistemas", price: "19,90" },
+                    { name: "Excel PRO", price: "19,90" },
+                    { name: "Inglês Kids", price: "19,90" },
+                    { name: "Informática Essencial", price: "19,90" },
+                    { name: "Marketing Digital", price: "19,90" },
+                    { name: "Inglês Fluente", price: "19,90" },
+                    { name: "Design Gráfico", price: "19,90" },
+                    { name: "Operador de Micro", price: "19,90" },
+                    { name: "Pacote Office", price: "19,90" },
+                    { name: "Especialista em Marketing & Vendas 360º", price: "19,90" },
                 ];
                 const tableBody = document.getElementById('afiliados-products-table-body');
                 if(tableBody){


### PR DESCRIPTION
## Resumo
- ajusta todos os valores em `COURSE_PRICES` para 19,90
- altera tabela de produtos para afiliados com novo preço
- muda texto do botão de teste gratuito para **Me matricular agora!**
- atualiza exemplos e scripts relacionados
- registra alteração em `Memoria.txt`

## Testes
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bd7ee1bd48326b7d6b37c7cd7f0ea