### PR TITLE
Add Design Gráfico Profissional mapping

### DIFF
--- a/course-form.js
+++ b/course-form.js
@@ -1,6 +1,7 @@
 const COURSE_PRICES = {
   "Excel PRO": 19.90,
   "Design Gráfico": 19.90,
+  "Design Gráfico Profissional": 19.90,
   "Analista e Desenvolvimento de Sistemas": 19.90,
   "Administração": 19.90,
   "Inglês Fluente": 19.90,

--- a/courses.js
+++ b/courses.js
@@ -5,6 +5,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   const descriptions = {
     'Excel PRO': 'Domine planilhas e crie relat\u00f3rios avan\u00e7ados para impulsionar sua produtividade.',
     'Design Gr\u00e1fico': 'Aprenda t\u00e9cnicas profissionais de cria\u00e7\u00e3o visual e destaque-se no mercado.',
+    'Design Gráfico Profissional': 'Aprenda técnicas completas de design para web e impressos.',
     'Analista e Desenvolvimento de Sistemas': 'Forma\u00e7\u00e3o completa para quem deseja programar e projetar sistemas de alta qualidade.',
     'Administra\u00e7\u00e3o': 'Construa habilidades essenciais para gerenciar neg\u00f3cios com efici\u00eancia.',
     'Ingl\u00eas Fluente': 'Alcance a flu\u00eancia no idioma mais requisitado pelo mercado de trabalho.',
@@ -19,6 +20,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   const details = {
     'Excel PRO': 'Curso completo para dominar planilhas, gráficos e automações no Excel, com foco em aplicações práticas.',
     'Design Gráfico': 'Aprenda a criar peças profissionais para web e impressão utilizando as principais ferramentas do mercado.',
+    'Design Gráfico Profissional': 'Illustrator, Photoshop, InDesign e CorelDRAW para projetos profissionais.',
     'Analista e Desenvolvimento de Sistemas': 'Formação abrangente em programação, análise de requisitos e desenvolvimento de sistemas de ponta a ponta.',
     'Administração': 'Capacitação em gestão empresarial, finanças e processos administrativos modernos.',
     'Inglês Fluente': 'Metodologia eficaz para alcançar fluência e se comunicar com confiança em qualquer situação.',

--- a/cursos.py
+++ b/cursos.py
@@ -7,6 +7,7 @@ router = APIRouter()
 CURSOS_OM: Dict[str, List[int]] = {
     "Mestre em Excel": [161, 197, 201, 560, 659],
     "Video Creator Profissional": [138, 240, 169, 254],
+    "Design Gráfico Profissional": [301, 302, 303, 304, 305, 306, 307],
     "Programador Master": [590, 176, 239, 203, 126, 252],
     "Desenvolvedor Web": [126, 239, 252, 237, 822],
     "Games Creator": [139, 124, 146, 473, 167],

--- a/index.html
+++ b/index.html
@@ -704,6 +704,7 @@
                 const COURSE_PRICES = {
             "Mestre em Excel": 19.90,
             "Video Creator Profissional": 19.90,
+            "Design Gráfico Profissional": 19.90,
             "Programador Master": 19.90,
             "Desenvolvedor Web": 19.90,
             "Games Creator": 19.90,
@@ -725,6 +726,7 @@
                 const COURSE_DESCRIPTIONS = {
             'Mestre em Excel': 'Domine o Excel de ponta a ponta. Inclui: Excel 2019, Avançado, Dashboard e cursos Fundamentais.',
             'Video Creator Profissional': 'Formação completa em vídeo com a suíte Adobe. Inclui Premiere, After Effects, Photoshop e Illustrator.',
+            'Design Gráfico Profissional': 'Formação completa em design com Illustrator, Photoshop, InDesign e CorelDRAW.',
             'Programador Master': 'Trilha full-stack do front ao back-end. Inclui Python, Java, PHP, Lógica, HTML/CSS e WordPress.',
             'Desenvolvedor Web': 'Planeje e publique sites profissionais. Inclui HTML/CSS, PHP, WordPress, Domínio e Illustrator.',
             'Games Creator': 'Criação de jogos do zero ao 3D. Inclui módulos 3D I, II e III, Games Online e Kids.',
@@ -746,6 +748,7 @@
                 const COURSE_DETAILS = {
             'Mestre em Excel': 'Domine o Excel do básico aos painéis avançados. Pacote: Excel 2019, Avançado, Dashboard e cursos Fundamentais.',
             'Video Creator Profissional': 'Formação completa com Premiere, After Effects, Photoshop e Illustrator para produções profissionais.',
+            'Design Gráfico Profissional': 'Formação completa em design com Illustrator, Photoshop, InDesign e CorelDRAW.',
             'Programador Master': 'Trilha full-stack com Python, Java, PHP, Lógica, HTML/CSS e WordPress para criar aplicações reais.',
             'Desenvolvedor Web': 'Desenvolvimento de sites com HTML/CSS, PHP, WordPress, gestão de domínios e Illustrator.',
             'Games Creator': 'Modelagem e programação de games 3D e online com módulos 3D I, II, III, Online e Kids.',

--- a/matricularassas.js
+++ b/matricularassas.js
@@ -68,7 +68,7 @@ document.addEventListener('DOMContentLoaded', () => {
         coursesSelect.appendChild(opt);
       });
     } catch (err) {
-      ['Excel PRO','Design Gráfico','Administração'].forEach(n => {
+      ['Excel PRO','Design Gráfico Profissional','Administração'].forEach(n => {
         const opt = document.createElement('option');
         opt.value = n;
         opt.textContent = n;


### PR DESCRIPTION
## Summary
- map new "Design Gráfico Profissional" course ids
- list the new course in static price and description tables
- expose the new course in course-form and fallback options

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685c31bd8c408326972ea40330a542c5