### PR TITLE
Configure API to run on port 10000

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "10000"]

--- a/Memoria.txt
+++ b/Memoria.txt
@@ -14,3 +14,4 @@ Usuario solicitou matricula automatica via index com envio de boas-vindas e link
 Usuario relatou problema no envio de WhatsApp ao matricular: numero 61986660241 era formatado como 5561986660241. Solicitou regra 'se tiver 55 nao pode ter 9'. O agente ajustou formatar_numero_whatsapp para remover o nono digito apos o DDD e garantir prefixo 55 apenas.
 Usuario solicitou manter login persistente e botao Acessar EAD. Implementado armazenamento do aluno e exibicao de saudacao e botao.
 Usuario relatou erro ao cadastrar e status 400. O agente ajustou registrar.py para enviar campos completos (whatsapp, endereco, unidade) e sanitizar cpf e telefone.
+Usuario solicitou rodar o serviço na porta 10000 no Docker. O agente alterou Dockerfile e docker-compose.yml para expor e usar a porta 10000.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build: .
     env_file: .env
     ports:
-      - "8000:8000"
+      - "10000:10000"
     depends_on:
       - db
   db:


### PR DESCRIPTION
## Summary
- run uvicorn on port 10000 by default
- expose port 10000 in docker-compose
- document the change in Memoria.txt

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_687eff7b8df08326800f4bba731fce31