### PR TITLE
Configura tentativas de conexao ao DB

### DIFF
--- a/EXEMPLOENV.txt
+++ b/EXEMPLOENV.txt
@@ -5,3 +5,4 @@ OM_BASE=https://meuappdecursos.com.br/ws/v2
 SENHA=senha para acessar o sistema
 TOKEN_KEY=token bruta do API EAD
 UNIDADE_ID=token da unidade escolar
+DB_MAX_RETRIES=5

--- a/disparos.py
+++ b/disparos.py
@@ -56,8 +56,17 @@ def get_conn(connect_timeout: int = 5):
     )
 
 
-def wait_for_db(max_attempts: int = 5, base_delay: float = 1.0) -> None:
-    """Tenta conectar ao banco até ``max_attempts`` com backoff exponencial."""
+def wait_for_db(max_attempts: int | None = None, base_delay: float = 1.0) -> None:
+    """Tenta conectar ao banco até ``max_attempts`` com backoff exponencial.
+
+    Se ``max_attempts`` não for informado, o valor será lido da variável de
+    ambiente ``DB_MAX_RETRIES`` (padrão 5).
+    """
+    if max_attempts is None:
+        try:
+            max_attempts = int(os.getenv("DB_MAX_RETRIES", "5"))
+        except ValueError:
+            max_attempts = 5
     for attempt in range(1, max_attempts + 1):
         try:
             with get_conn() as conn, conn.cursor() as cur:


### PR DESCRIPTION
## Summary
- parametro `wait_for_db` agora pode ler quantidade de tentativas da variavel `DB_MAX_RETRIES`
- exemplo de `.env` atualizado

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882ba0d5b9883269b6c237a59c9a727