### PR TITLE
Disable DB setup

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,12 +1,7 @@
-import asyncio
-import os
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.staticfiles import StaticFiles
 
-from .models import init_db
 from .routers import arquivos, listas, contatos, mensagens, disparos
-from .worker import worker_loop
 
 app = FastAPI(title="Disparos WhatsApp")
 app.add_middleware(
@@ -25,5 +20,4 @@ app.include_router(disparos.router)
 
 @app.on_event("startup")
 async def startup():
-    await init_db()
-    asyncio.create_task(worker_loop())
+    pass

--- a/main.py
+++ b/main.py
@@ -31,8 +31,6 @@ import registrar
 import auth
 import disparos
 from app import whatsapp
-from backend.app import models as disparo_models
-from backend.app.worker import worker_loop
 from backend.app.routers import arquivos as arq_r, listas as listas_r, contatos as cont_r, mensagens as msg_r, disparos as disp_r
 
 # ──────────────────────────────────────────────────────────
@@ -85,12 +83,9 @@ app.include_router(disp_r.router)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    """Preparação inicial do serviço com retries para o banco."""
+    """Preparação inicial do serviço (sem banco de dados)."""
     send_startup_message()
-    await asyncio.to_thread(disparos.wait_for_db)
-    await asyncio.to_thread(disparos.ensure_tables)
-    await disparo_models.init_db()
-    asyncio.create_task(worker_loop())
+    # Banco de dados desativado temporariamente
     yield
 
 app.router.lifespan_context = lifespan


### PR DESCRIPTION
## Summary
- remove DB initialization during startup
- skip DB and worker setup in backend

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68856a843d6c8326b03f1d8077d76fed