### PR TITLE
Fix course enroll button link

### DIFF
--- a/courses.js
+++ b/courses.js
@@ -76,7 +76,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       const addBtn = card.querySelector('.enroll');
       const detailsBtn = card.querySelector('.details');
       addBtn.addEventListener('click', () => {
-        window.location.href = `matricular.html?curso=${encodeURIComponent(name)}`;
+        window.location.href = `assinatura.html?curso=${encodeURIComponent(name)}`;
       });
       if (detailsBtn) {
         detailsBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- adjust `courses.js` to redirect to `assinatura.html` instead of a missing page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68869c1b616c832696c7d34b9ae2cc9d