### PR TITLE
Adjust course fetch URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,11 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=Poppins:wght@600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
   <link rel="icon" href="favicon.jpg" type="image/jpeg" />
+  <script>
+    // Permite definir a URL base da API dinamicamente, caindo em
+    // https://api.cedbrasilia.com.br quando nenhuma é informada
+    window.API_BASE = window.API_BASE || 'https://api.cedbrasilia.com.br';
+  </script>
 
   <style>
     :root {
@@ -857,8 +862,9 @@
     let selectedCourse = null;
 
     async function fetchCourses() {
+      const url = `${window.API_BASE}/cursos`;
       try {
-        const response = await fetch('https://api.cedbrasilia.com.br/cursos');
+        const response = await fetch(url);
         if (!response.ok) {
           throw new Error(`HTTP error! status: ${response.status}`);
         }
@@ -880,7 +886,7 @@
         });
         loadCourses();
       } catch (error) {
-        console.error('Erro ao carregar cursos da API:', error);
+        console.error('Erro ao carregar cursos da API:', url, error);
         showNotification('Erro ao carregar cursos. Tente novamente mais tarde.', 'error');
         availableCourses = Object.keys(COURSE_PRICES).map(name => ({
           name,


### PR DESCRIPTION
## Summary
- configure API base URL in `index.html`
- fetch courses using the configurable base

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6886d35a98a08326b7bc6c3dca90babd