### PR TITLE
Fix API URL to avoid CORS

### DIFF
--- a/assinatura.html
+++ b/assinatura.html
@@ -217,6 +217,7 @@
     </footer>
 
     <script>
+        const API_BASE = window.API_BASE || 'https://api.cedbrasilia.com.br';
         document.addEventListener('DOMContentLoaded', () => {
             document.getElementById('currentYear').textContent = new Date().getFullYear();
 
@@ -230,8 +231,8 @@
             const formMessage = document.getElementById('form-message');
             const submitButton = document.getElementById('submitButton');
 
-            const API_CURSOS_URL = 'https://api.cedbrasilia.com.br/cursos';
-            const WEBHOOK_MATRICULAR_URL = 'https://api.cedbrasilia.com.br/matricular';
+            const API_CURSOS_URL = `${API_BASE}/cursos`;
+            const WEBHOOK_MATRICULAR_URL = `${API_BASE}/matricular`;
 
             async function loadCourses() {
                 try {

--- a/conectar_site_com_asaas.js
+++ b/conectar_site_com_asaas.js
@@ -1,8 +1,9 @@
 // Exemplo de integração no site (frontend)
 // Envia os dados do aluno para a API e redireciona para o link de pagamento.
+const API_BASE = window.API_BASE || 'https://api.cedbrasilia.com.br';
 
 async function gerarLinkPagamento(dadosAluno) {
-  const resposta = await fetch('https://api.cedbrasilia.com.br/asaas/checkout', {
+  const resposta = await fetch(`${API_BASE}/asaas/checkout`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(dadosAluno)

--- a/course-form.js
+++ b/course-form.js
@@ -1,3 +1,4 @@
+const API_BASE = window.API_BASE || 'https://api.cedbrasilia.com.br';
 const COURSE_PRICES = {
   "Excel PRO": 19.90,
   "Design Gráfico": 19.90,
@@ -45,7 +46,7 @@ function normalizarNumero(num) {
 }
 
 async function gerarLinkPagamento(dadosAluno) {
-  const resposta = await fetch('https://api.cedbrasilia.com.br/asaas/checkout', {
+  const resposta = await fetch(`${API_BASE}/asaas/checkout`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(dadosAluno)
@@ -63,7 +64,7 @@ async function gerarLinkPagamento(dadosAluno) {
 
 async function obterIdsCurso(nome) {
   try {
-    const res = await fetch('https://api.cedbrasilia.com.br/cursos');
+    const res = await fetch(`${API_BASE}/cursos`);
     const data = await res.json();
     return (data.cursos && data.cursos[nome]) ? data.cursos[nome] : [];
   } catch (_) {

--- a/courses.js
+++ b/courses.js
@@ -1,4 +1,5 @@
 document.addEventListener('DOMContentLoaded', async () => {
+  const API_BASE = window.API_BASE || 'https://api.cedbrasilia.com.br';
   const courseList = document.getElementById('course-list');
   if (!courseList) return;
 
@@ -34,7 +35,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
 
   try {
-    const res = await fetch('https://api.cedbrasilia.com.br/cursos');
+    const res = await fetch(`${API_BASE}/cursos`);
     const data = await res.json();
     const cursos = data.cursos || {};
 

--- a/index.html
+++ b/index.html
@@ -702,6 +702,7 @@
     <div id="notification-popup"></div>
 
     <script>
+        const API_BASE = window.API_BASE || 'https://api.cedbrasilia.com.br';
 
                 const COURSE_PRICES = {
             "Mestre em Excel": 19.90,
@@ -774,7 +775,7 @@
 
         async function fetchCourses() {
             try {
-                const response = await fetch('https://api.cedbrasilia.com.br/cursos');
+                const response = await fetch(`${API_BASE}/cursos`);
                 if (!response.ok) {
                     throw new Error(`HTTP error! status: ${response.status}`);
                 }
@@ -921,7 +922,7 @@
                 loginSubmitButton.classList.add('opacity-50', 'cursor-not-allowed');
                 loginSubmitButton.innerHTML = '<i class="fa-solid fa-circle-notch fa-spin"></i> Entrando...';
 
-                const url = `https://api.cedbrasilia.com.br/login/?usuario=${encodeURIComponent(usuario)}&senha=${encodeURIComponent(senha)}`;
+                const url = `${API_BASE}/login/?usuario=${encodeURIComponent(usuario)}&senha=${encodeURIComponent(senha)}`;
                 window.location.href = url;
             });
 
@@ -1103,7 +1104,7 @@
 
             // **NOVA FUNÇÃO** para criar a assinatura
             async function criarAssinatura(dadosAssinatura) {
-                const resposta = await fetch('https://api.cedbrasilia.com.br/asaas/assinatura', {
+                const resposta = await fetch(`${API_BASE}/asaas/assinatura`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify(dadosAssinatura)

--- a/login.html
+++ b/login.html
@@ -47,6 +47,7 @@
         </div>
     </div>
     <script>
+        const API_BASE = window.API_BASE || 'https://api.cedbrasilia.com.br';
         document.addEventListener('DOMContentLoaded', () => {
             const loginForm = document.getElementById('loginForm');
             const themeCheckbox = document.getElementById('theme-checkbox');
@@ -75,7 +76,7 @@
                 const msg = document.getElementById('loginMsg');
                 msg.innerHTML = '<i class="fa-solid fa-circle-notch fa-spin text-green-500 text-xl"></i> Redirecionando...';
                 msg.className = 'mt-4 text-center text-gray-300';
-                const url = `https://api.cedbrasilia.com.br/login/?usuario=${encodeURIComponent(usuario)}&senha=${encodeURIComponent(senha)}`;
+                const url = `${API_BASE}/login/?usuario=${encodeURIComponent(usuario)}&senha=${encodeURIComponent(senha)}`;
                 window.location.href = url;
             });
         });

--- a/matricularassas.js
+++ b/matricularassas.js
@@ -1,6 +1,7 @@
 // Script for matricularassas.html
 
 // Reuses validation and masking logic from assinatura page
+const API_BASE = window.API_BASE || 'https://api.cedbrasilia.com.br';
 
 function applyWhatsappMask(value) {
   value = value.replace(/\D/g, "");
@@ -58,7 +59,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const loadCourses = async () => {
     try {
-      const res = await fetch('https://api.cedbrasilia.com.br/cursos');
+      const res = await fetch(`${API_BASE}/cursos`);
       const data = await res.json();
       const nomes = Object.keys(data.cursos || {});
       nomes.forEach(n => {
@@ -118,7 +119,7 @@ document.addEventListener('DOMContentLoaded', () => {
     formMessage.className = 'text-center loading-message';
 
     try {
-      const res = await fetch('https://api.cedbrasilia.com.br/matricularasaas', {
+      const res = await fetch(`${API_BASE}/matricularasaas`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ nome, cpf, phone, cursos })


### PR DESCRIPTION
## Summary
- support configurable API_BASE in multiple pages and scripts
- update fetch calls to use API_BASE constant

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688953ae35088326bc2ee6975b8f22e4