### PR TITLE
Adiciona cursos fixos no index

### DIFF
--- a/index.html
+++ b/index.html
@@ -770,49 +770,46 @@
             'Youtuber': 'Curso Youtuber, After Effects, Canva e WhatsApp Business.'
         };
 
+        const COURSE_IDS = {
+            "Mestre em Excel": [161, 197, 201, 560, 659],
+            "Video Creator Profissional": [138, 240, 169, 254],
+            "Design Gráfico Profissional": [751, 169, 822, 78, 441],
+            "Programador Master": [590, 176, 239, 203, 126, 252],
+            "Desenvolvedor Web": [126, 239, 252, 237, 822],
+            "Games Creator": [139, 124, 146, 473, 167],
+            "Projetista Alto Nível": [135, 193, 195, 396, 541],
+            "Administração de Pessoal": [156, 198, 214, 129],
+            "Social Media Pro": [199, 780, 441, 202, 734, 264, 236],
+            "Vendedor Digital": [123, 207, 236, 255, 222],
+            "Crianças do Futuro": [92, 93, 94, 513, 568, 594, 705, 723, 782, 783, 837, 838],
+            "Melhor Idade": [168, 599, 234, 627, 220],
+            "Líder do Futuro": [154, 144, 214, 156, 129],
+            "Auxiliar Contábil": [200, 183, 560, 129],
+            "Auxiliar de Escritório": [754, 130, 160, 161, 162],
+            "Segurança da Saúde": [271, 316, 334, 360, 426, 216],
+            "Cuidador de Idosos": [276, 155, 271, 222],
+            "Operador de Logística": [265, 161, 183, 201, 236],
+            "Youtuber": [136, 240, 441, 264],
+        };
+
         let availableCourses = [];
         let selectedCourse = null;
 
-        async function fetchCourses() {
-            try {
-                const response = await fetch(`${API_BASE}/cursos`);
-                if (!response.ok) {
-                    throw new Error(`HTTP error! status: ${response.status}`);
-                }
-                const data = await response.json();
-                const cursosObj = data.cursos || {};
-                availableCourses = Object.entries(cursosObj)
-                    .filter(([n]) => n !== 'None')
-                    .map(([name, ids]) => ({
-                        name,
-                        ids,
-                        price: COURSE_PRICES[name] || 0,
-                        description: COURSE_DESCRIPTIONS[name] || 'Curso profissionalizante do CED BRASIL.',
-                        detail: COURSE_DETAILS[name] || COURSE_DESCRIPTIONS[name] || ''
-                    }));
-                availableCourses.sort((a, b) => {
-                    if (a.name === 'Mestre em Excel') return -1;
-                    if (b.name === 'Mestre em Excel') return 1;
-                    return a.name.localeCompare(b.name);
-                });
-                loadCourses();
-            } catch (error) {
-                console.error('Erro ao carregar cursos da API:', error);
-                showNotification('Erro ao carregar cursos. Tente novamente mais tarde.', 'error');
-                availableCourses = Object.keys(COURSE_PRICES).map(name => ({
-                    name,
-                    ids: [],
-                    price: COURSE_PRICES[name] || 0,
-                    description: COURSE_DESCRIPTIONS[name] || 'Curso profissionalizante do CED BRASIL.',
-                    detail: COURSE_DETAILS[name] || COURSE_DESCRIPTIONS[name] || ''
-                }));
-                availableCourses.sort((a, b) => {
-                    if (a.name === 'Mestre em Excel') return -1;
-                    if (b.name === 'Mestre em Excel') return 1;
-                    return a.name.localeCompare(b.name);
-                });
-                loadCourses();
-            }
+        function fetchCourses() {
+            availableCourses = Object.entries(COURSE_IDS).map(([name, ids]) => ({
+                name,
+                ids,
+                price: COURSE_PRICES[name] || 0,
+                description: COURSE_DESCRIPTIONS[name] || 'Curso profissionalizante do CED BRASIL.',
+                detail: COURSE_DETAILS[name] || COURSE_DESCRIPTIONS[name] || ''
+            }));
+            availableCourses.sort((a, b) => {
+                if (a.name === 'Mestre em Excel') return -1;
+                if (b.name === 'Mestre em Excel') return 1;
+                return a.name.localeCompare(b.name);
+            });
+            loadCourses();
+            return Promise.resolve();
         }
 
         function loadCourses() {


### PR DESCRIPTION
## Summary
- insere os IDs dos cursos direto no `index.html`
- ajusta `fetchCourses()` para usar os dados locais e não fazer requisição

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6889592f244883269021612e0aff3cfb